### PR TITLE
NSArray: Implement IList<NSObject>

### DIFF
--- a/plist-cil.test/NSArrayTests.cs
+++ b/plist-cil.test/NSArrayTests.cs
@@ -1,0 +1,73 @@
+﻿using Claunia.PropertyList;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace plistcil.test
+{
+    [TestFixture]
+    public class NSArrayTests
+    {
+        /// <summary>
+        /// Tests the addition of a .NET object to the NSArray
+        /// </summary>
+        [Test]
+        public void AddAndContainsObjectTest()
+        {
+            NSArray array = new NSArray();
+            array.Add(1);
+
+            Assert.IsTrue(array.Contains(1));
+            Assert.IsFalse(array.Contains(2));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="NSArray.IndexOf(object)"/> method for .NET objects.
+        /// </summary>
+        [Test]
+        public void IndexOfTest()
+        {
+            NSArray array = new NSArray();
+            array.Add(1);
+            array.Add("test");
+
+            Assert.AreEqual(0, array.IndexOf(1));
+            Assert.AreEqual(1, array.IndexOf("test"));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="NSArray.Insert(int, object)"/> method for a 
+        /// .NET object.
+        /// </summary>
+        [Test]
+        public void InsertTest()
+        {
+            NSArray array = new NSArray();
+            array.Add(0);
+            array.Add(1);
+            array.Add(2);
+
+            array.Insert(1, "test");
+
+            Assert.AreEqual(4, array.Count);
+            Assert.AreEqual("test", array.ObjectAtIndex(1).ToObject());
+        }
+
+        /// <summary>
+        /// Tests the <see cref="NSArray.Remove(object)"/> method for a .NET object.
+        /// </summary>
+        [Test]
+        public void RemoveTest()
+        {
+            NSArray array = new NSArray();
+            array.Add(0);
+            Assert.IsFalse(array.Remove((object)1));
+            Assert.IsTrue(array.Remove((object)0));
+
+            Assert.AreEqual(0, array.Count);
+        }
+    }
+}

--- a/plist-cil.test/ParseTest.cs
+++ b/plist-cil.test/ParseTest.cs
@@ -131,7 +131,7 @@ namespace plistcil.test
             Assert.True(d.Count == 5);
             Assert.True(((NSString)d.ObjectForKey("keyA")).ToString().Equals("valueA"));
             Assert.True(((NSString)d.ObjectForKey("key&B")).ToString().Equals("value&B"));
-            Assert.True(((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc)));
+            Assert.True(((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc).ToLocalTime()));
             Assert.True(ArrayEquals(((NSData)d.ObjectForKey("data")).Bytes,
                 new byte[]{ 0x00, 0x00, 0x00, 0x04, 0x10, 0x41, 0x08, 0x20, (byte)0x82 }));
             NSArray a = (NSArray)d.ObjectForKey("array");

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,6 +35,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NSArrayTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ParseTest.cs" />
     <Compile Include="IssueTest.cs" />
@@ -119,7 +120,8 @@
       <Name>plist-cil</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
-    <Folder Include="test-files\" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/plist-cil/BinaryPropertyListParser.cs
+++ b/plist-cil/BinaryPropertyListParser.cs
@@ -313,7 +313,7 @@ namespace Claunia.PropertyList
                             int objRef = (int)ParseUnsignedInt(CopyOfRange(bytes,
                                              offset + arrayOffset + i * objectRefSize,
                                              offset + arrayOffset + (i + 1) * objectRefSize));
-                            array.SetValue(i, ParseObject(objRef));
+                            array.Add(ParseObject(objRef));
                         }
                         return array;
 

--- a/plist-cil/NSArray.IList.cs
+++ b/plist-cil/NSArray.IList.cs
@@ -1,0 +1,139 @@
+﻿// plist-cil - An open source library to parse and generate property lists for .NET
+// Copyright (C) 2016 Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Claunia.PropertyList
+{
+    partial class NSArray : IList<NSObject>
+    {
+        /// <inheritdoc/>
+        public NSObject this[int index]
+        {
+            get
+            {
+                return this.array[index];
+            }
+
+            set
+            {
+                this.array[index] = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public void Add(object item)
+        {
+            this.Add(NSObject.Wrap(item));
+        }
+
+        /// <inheritdoc/>
+        public void Add(NSObject item)
+        {
+            this.array.Add(item);
+        }
+
+        /// <inheritdoc/>
+        public void Clear()
+        {
+            this.array.Clear();
+        }
+
+        public bool Contains(object item)
+        {
+            return this.Contains(NSObject.Wrap(item));
+        }
+
+        /// <inheritdoc/>
+        public bool Contains(NSObject item)
+        {
+            return this.array.Contains(item);
+        }
+
+        /// <inheritdoc/>
+        public void CopyTo(NSObject[] array, int arrayIndex)
+        {
+            this.array.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<NSObject> GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        public int IndexOf(object item)
+        {
+            return this.array.IndexOf(NSObject.Wrap(item));
+        }
+
+        /// <inheritdoc/>
+        public int IndexOf(NSObject item)
+        {
+            return this.array.IndexOf(item);
+        }
+
+        public void Insert(int index, object item)
+        {
+            this.Insert(index, NSObject.Wrap(item));
+        }
+
+        /// <inheritdoc/>
+        public void Insert(int index, NSObject item)
+        {
+            this.array.Insert(index, item);
+        }
+
+        public bool Remove(object item)
+        {
+            return this.Remove(NSObject.Wrap(item));
+        }
+
+        /// <inheritdoc/>
+        public bool Remove(NSObject item)
+        {
+            return this.array.Remove(item);
+        }
+
+        /// <inheritdoc/>
+        public void RemoveAt(int index)
+        {
+            this.array.RemoveAt(index);
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.array.GetEnumerator();
+        }
+    }
+}

--- a/plist-cil/NSArray.cs
+++ b/plist-cil/NSArray.cs
@@ -23,6 +23,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 
 namespace Claunia.PropertyList
@@ -32,9 +34,9 @@ namespace Claunia.PropertyList
     /// </summary>
     /// @author Daniel Dreibrodt
     /// @author Natalia Portillo
-    public class NSArray : NSObject
+    public partial class NSArray : NSObject
     {
-        NSObject[] array;
+        List<NSObject> array;
 
         /// <summary>
         /// Creates an empty array of the given length.
@@ -42,7 +44,7 @@ namespace Claunia.PropertyList
         /// <param name="length">The number of elements this array will be able to hold.</param>
         public NSArray(int length)
         {
-            array = new NSObject[length];
+            array = new List<NSObject>(length);
         }
 
         /// <summary>
@@ -51,7 +53,7 @@ namespace Claunia.PropertyList
         /// <param name="a">The array which should be wrapped by the NSArray.</param>
         public NSArray(params NSObject[] a)
         {
-            array = a;
+            array = new List<NSObject>(a);
         }
 
         /// <summary>
@@ -59,6 +61,7 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <returns>The object at the given index.</returns>
         /// <param name="i">The index of the object.</param>
+        [Obsolete]
         public NSObject ObjectAtIndex(int i)
         {
             return array[i];
@@ -69,14 +72,10 @@ namespace Claunia.PropertyList
         /// The array will be resized.
         /// </summary>
         /// <param name="i">The index of the object</param>
+        [Obsolete]
         public void Remove(int i)
         {
-            if ((i >= array.Length) || (i < 0))
-                throw new IndexOutOfRangeException("invalid index:" + i + ";the array length is " + array.Length);
-            NSObject[] newArray = new NSObject[array.Length - 1];
-            Array.Copy(array, 0, newArray, 0, i);
-            Array.Copy(array, i + 1, newArray, i, array.Length - i - 1);
-            array = newArray;
+            this.array.RemoveAt(i);
         }
 
         /// <summary>
@@ -85,6 +84,7 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <param name="key">The index where to store the object.</param>
         /// <param name="value">The object.</param>
+        [Obsolete]
         public void SetValue(int key, Object value)
         {
             if (value == null)
@@ -97,9 +97,10 @@ namespace Claunia.PropertyList
         /// Any changes to the values of this array will also affect the NSArray.
         /// </summary>
         /// <returns>The actual array represented by this NSArray.</returns>
+        [Obsolete]
         public NSObject[] GetArray()
         {
-            return array;
+            return array.ToArray();
         }
 
         /// <summary>
@@ -110,7 +111,7 @@ namespace Claunia.PropertyList
         {
             get
             {
-                return array.Length;
+                return array.Count;
             }
         }
 
@@ -120,6 +121,7 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <returns><c>true</c>, when the object could be found. <c>false</c> otherwise.</returns>
         /// <param name="obj">The object to look for.</param>
+        [Obsolete]
         public bool ContainsObject(Object obj)
         {
             NSObject nso = NSObject.Wrap(obj);
@@ -140,10 +142,11 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <returns>The index of the object, if it was found. -1 otherwise.</returns>
         /// <param name="obj">The object to look for.</param>
+        [Obsolete]
         public int IndexOfObject(Object obj)
         {
             NSObject nso = NSObject.Wrap(obj);
-            for (int i = 0; i < array.Length; i++)
+            for (int i = 0; i < array.Count; i++)
             {
                 if (array[i].Equals(nso))
                 {
@@ -161,10 +164,11 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <returns>The index of the object, if it was found. -1 otherwise.</returns>
         /// <param name="obj">The object to look for.</param>
+        [Obsolete]
         public int IndexOfIdenticalObject(Object obj)
         {
             NSObject nso = NSObject.Wrap(obj);
-            for (int i = 0; i < array.Length; i++)
+            for (int i = 0; i < array.Count; i++)
             {
                 if (array[i] == nso)
                 {
@@ -180,7 +184,7 @@ namespace Claunia.PropertyList
         /// <returns>The value of the highest index in the array.</returns>
         public NSObject LastObject()
         {
-            return array[array.Length - 1];
+            return array[array.Count - 1];
         }
 
         /// <summary>
@@ -208,14 +212,14 @@ namespace Claunia.PropertyList
         {
             if (obj.GetType().Equals(typeof(NSArray)))
             {
-                return ArrayEquals(((NSArray)obj).GetArray(), array);
+                return ArrayEquals(((NSArray)obj).GetArray(), this.GetArray());
             }
             else
             {
                 NSObject nso = NSObject.Wrap(obj);
                 if (nso.GetType().Equals(typeof(NSArray)))
                 {
-                    return ArrayEquals(((NSArray)nso).GetArray(), array);
+                    return ArrayEquals(((NSArray)nso).GetArray(), this.GetArray());
                 }
             }
             return false;
@@ -258,7 +262,7 @@ namespace Claunia.PropertyList
 
         internal override void ToBinary(BinaryPropertyListWriter outPlist)
         {
-            outPlist.WriteIntHeader(0xA, array.Length);
+            outPlist.WriteIntHeader(0xA, array.Count);
             foreach (NSObject obj in array)
             {
                 outPlist.WriteID(outPlist.GetID(obj));
@@ -308,7 +312,7 @@ namespace Claunia.PropertyList
             Indent(ascii, level);
             ascii.Append(ASCIIPropertyListParser.ARRAY_BEGIN_TOKEN);
             int indexOfLastNewLine = ascii.ToString().LastIndexOf(NEWLINE, StringComparison.Ordinal);
-            for (int i = 0; i < array.Length; i++)
+            for (int i = 0; i < array.Count; i++)
             {
                 Type objClass = array[i].GetType();
                 if ((objClass.Equals(typeof(NSDictionary)) || objClass.Equals(typeof(NSArray)) || objClass.Equals(typeof(NSData)))
@@ -325,7 +329,7 @@ namespace Claunia.PropertyList
                     array[i].ToASCII(ascii, 0);
                 }
 
-                if (i != array.Length - 1)
+                if (i != array.Count - 1)
                     ascii.Append(ASCIIPropertyListParser.ARRAY_ITEM_DELIMITER_TOKEN);
 
                 if (ascii.Length - indexOfLastNewLine > ASCII_LINE_LENGTH)
@@ -342,7 +346,7 @@ namespace Claunia.PropertyList
             Indent(ascii, level);
             ascii.Append(ASCIIPropertyListParser.ARRAY_BEGIN_TOKEN);
             int indexOfLastNewLine = ascii.ToString().LastIndexOf(NEWLINE, StringComparison.Ordinal);
-            for (int i = 0; i < array.Length; i++)
+            for (int i = 0; i < array.Count; i++)
             {
                 Type objClass = array[i].GetType();
                 if ((objClass.Equals(typeof(NSDictionary)) || objClass.Equals(typeof(NSArray)) || objClass.Equals(typeof(NSData)))
@@ -359,7 +363,7 @@ namespace Claunia.PropertyList
                     array[i].ToASCIIGnuStep(ascii, 0);
                 }
 
-                if (i != array.Length - 1)
+                if (i != array.Count - 1)
                     ascii.Append(ASCIIPropertyListParser.ARRAY_ITEM_DELIMITER_TOKEN);
 
                 if (ascii.Length - indexOfLastNewLine > ASCII_LINE_LENGTH)
@@ -382,10 +386,10 @@ namespace Claunia.PropertyList
             if (!(obj is NSArray))
                 return false;
 
-            if (array.Length != ((NSArray)obj).array.Length)
+            if (array.Count != ((NSArray)obj).array.Count)
                 return false;
 
-            for (int i = 0; i < array.Length; i++)
+            for (int i = 0; i < array.Count; i++)
                 if (!array[i].Equals(((NSArray)obj).ObjectAtIndex(i)))
                     return false;
 

--- a/plist-cil/NSObject.cs
+++ b/plist-cil/NSObject.cs
@@ -184,7 +184,7 @@ namespace Claunia.PropertyList
             NSArray arr = new NSArray(value.Length);
             for (int i = 0; i < value.Length; i++)
             {
-                arr.SetValue(i, Wrap(value[i]));
+                arr.Add(Wrap(value[i]));
             }
             return arr;
         }
@@ -293,7 +293,7 @@ namespace Claunia.PropertyList
                     bool[] array = (bool[])o;
                     NSArray nsa = new NSArray(array.Length);
                     for (int i = 0; i < array.Length; i++)
-                        nsa.SetValue(i, Wrap(array[i]));
+                        nsa.Add(Wrap(array[i]));
                     return nsa;
                 }
                 if (cc.Equals(typeof(float)))
@@ -301,7 +301,7 @@ namespace Claunia.PropertyList
                     float[] array = (float[])o;
                     NSArray nsa = new NSArray(array.Length);
                     for (int i = 0; i < array.Length; i++)
-                        nsa.SetValue(i, Wrap(array[i]));
+                        nsa.Add(Wrap(array[i]));
                     return nsa;
                 }
                 if (cc.Equals(typeof(double)))
@@ -309,7 +309,7 @@ namespace Claunia.PropertyList
                     double[] array = (double[])o;
                     NSArray nsa = new NSArray(array.Length);
                     for (int i = 0; i < array.Length; i++)
-                        nsa.SetValue(i, Wrap(array[i]));
+                        nsa.Add(Wrap(array[i]));
                     return nsa;
                 }
                 if (cc.Equals(typeof(short)))
@@ -317,7 +317,7 @@ namespace Claunia.PropertyList
                     short[] array = (short[])o;
                     NSArray nsa = new NSArray(array.Length);
                     for (int i = 0; i < array.Length; i++)
-                        nsa.SetValue(i, Wrap(array[i]));
+                        nsa.Add(Wrap(array[i]));
                     return nsa;
                 }
                 if (cc.Equals(typeof(int)))
@@ -325,7 +325,7 @@ namespace Claunia.PropertyList
                     int[] array = (int[])o;
                     NSArray nsa = new NSArray(array.Length);
                     for (int i = 0; i < array.Length; i++)
-                        nsa.SetValue(i, Wrap(array[i]));
+                        nsa.Add(Wrap(array[i]));
                     return nsa;
                 }
                 if (cc.Equals(typeof(long)))
@@ -333,7 +333,7 @@ namespace Claunia.PropertyList
                     long[] array = (long[])o;
                     NSArray nsa = new NSArray(array.Length);
                     for (int i = 0; i < array.Length; i++)
-                        nsa.SetValue(i, Wrap(array[i]));
+                        nsa.Add(Wrap(array[i]));
                     return nsa;
                 }
                     return Wrap((Object[])o);

--- a/plist-cil/XmlPropertyListParser.cs
+++ b/plist-cil/XmlPropertyListParser.cs
@@ -140,7 +140,7 @@ namespace Claunia.PropertyList
                 NSArray array = new NSArray(children.Count);
                 for (int i = 0; i < children.Count; i++)
                 {
-                    array.SetValue(i, ParseObject(children[i]));
+                    array.Add(ParseObject(children[i]));
                 }
                 return array;
             }

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -144,6 +144,7 @@
       <Gettext-ScanForTranslations>False</Gettext-ScanForTranslations>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Compile Include="NSArray.IList.cs" />
     <None Include="plist-cil.nuspec" />
     <None Include="plist-cil.snk" />
   </ItemGroup>


### PR DESCRIPTION
This PR makes `NSArray` implement `IList<NSObject>`, just like `NSDictionary` implements `IDictionary<string, NSObject>`. It also changes the underlying storage from an array to a `List<NSObject>`, which makes operations like resizing the array more transparent.

Feedback is welcome!