### PR TITLE
NSNumber: Keep track of the original number type when parsing from XML

### DIFF
--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -126,6 +126,18 @@ namespace plistcil.test
             NSDictionary dict = (NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue49.plist"));
             Assert.AreEqual(0, dict.Count);
         }
+
+        [Test]
+        public static void TestRealInResourceRule()
+        {
+            NSDictionary dict = (NSDictionary)XmlPropertyListParser.Parse(new FileInfo("test-files/ResourceRules.plist"));
+            Assert.AreEqual(1, dict.Count);
+            Assert.IsTrue(dict.ContainsKey("weight"));
+
+            var weight = dict["weight"].ToObject();
+            Assert.IsInstanceOf<double>(weight);
+            Assert.AreEqual(10d, (double)weight);
+        }
     }
 }
 

--- a/plist-cil.test/NSNumberTests.cs
+++ b/plist-cil.test/NSNumberTests.cs
@@ -2,8 +2,10 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace plistcil.test
@@ -17,6 +19,57 @@ namespace plistcil.test
             var number = new NSNumber("10032936613", NSNumber.INTEGER);
             Assert.AreEqual(NSNumber.INTEGER, number.GetNSNumberType());
             Assert.AreEqual(10032936613, number.ToObject());
+        }
+
+        // The tests below make sure the numbers are being parsed correctly, and do not depend on the culture info
+        // being set. Especially, decimal point may vary between cultures and we don't want to take a dependency on that
+        // The value being used comes seen in a real property list:
+        // <key>TimeZoneOffsetFromUTC</key>
+        // <real>7200.000000</real>
+
+        [Test]
+        [SetCulture("en-US")]
+        public static void ParseNumberEnTest()
+        {
+            var number = new NSNumber("7200.000001");
+            Assert.IsTrue(number.isReal());
+            Assert.AreEqual(7200.000001d, number.ToDouble());
+        }
+
+        [Test]
+        [SetCulture("nl-BE")]
+        public static void ParseNumberNlTest()
+        {
+            // As seen in a real property list:
+            // <key>TimeZoneOffsetFromUTC</key>
+            // <real>7200.000000</real>
+            var number = new NSNumber("7200.000001");
+            Assert.IsTrue(number.isReal());
+            Assert.AreEqual(7200.000001d, number.ToDouble());
+        }
+
+        [Test]
+        [SetCulture("en-US")]
+        public static void ParseNumberEnTest2()
+        {
+            // As seen in a real property list:
+            // <key>TimeZoneOffsetFromUTC</key>
+            // <real>7200.000000</real>
+            var number = new NSNumber("7200.000000", NSNumber.REAL);
+            Assert.IsTrue(number.isReal());
+            Assert.AreEqual(7200d, number.ToDouble());
+        }
+
+        [Test]
+        [SetCulture("nl-BE")]
+        public static void ParseNumberNlTest2()
+        {
+            // As seen in a real property list:
+            // <key>TimeZoneOffsetFromUTC</key>
+            // <real>7200.000000</real>
+            var number = new NSNumber("7200.000000", NSNumber.REAL);
+            Assert.IsTrue(number.isReal());
+            Assert.AreEqual(7200d, number.ToDouble());
         }
     }
 }

--- a/plist-cil.test/NSNumberTests.cs
+++ b/plist-cil.test/NSNumberTests.cs
@@ -1,0 +1,22 @@
+﻿using Claunia.PropertyList;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace plistcil.test
+{
+    [TestFixture]
+    public class NSNumberTests
+    {
+        [Test]
+        public static void NSNumberConstructorTest()
+        {
+            var number = new NSNumber("10032936613", NSNumber.INTEGER);
+            Assert.AreEqual(NSNumber.INTEGER, number.GetNSNumberType());
+            Assert.AreEqual(10032936613, number.ToObject());
+        }
+    }
+}

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NSArrayTests.cs" />
+    <Compile Include="NSNumberTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ParseTest.cs" />
     <Compile Include="IssueTest.cs" />
@@ -111,6 +112,9 @@
     <None Include="..\test-files\test-ascii.plist">
       <Link>test-files\test-ascii.plist</Link>
       <Gettext-ScanForTranslations>False</Gettext-ScanForTranslations>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="test-files\ResourceRules.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/plist-cil.test/test-files/ResourceRules.plist
+++ b/plist-cil.test/test-files/ResourceRules.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>weight</key>
+    <real>10</real>
+  </dict>
+</plist>

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -74,13 +74,32 @@ namespace Claunia.PropertyList
             switch (type)
             {
                 case INTEGER:
+                    doubleValue = longValue = BinaryPropertyListParser.ParseLong(bytes);
+                    break;
+
+                case REAL:
+                    doubleValue = BinaryPropertyListParser.ParseDouble(bytes);
+                    longValue = (long)Math.Round(doubleValue);
+                    break;
+
+                default:
+                    throw new ArgumentException("Type argument is not valid.");
+            }
+            this.type = type;
+        }
+
+        public NSNumber(string text, int type)
+        {
+            switch (type)
+            {
+                case INTEGER:
                     {
-                        doubleValue = longValue = BinaryPropertyListParser.ParseLong(bytes);
+                        doubleValue = longValue = long.Parse(text);
                         break;
                     }
                 case REAL:
                     {
-                        doubleValue = BinaryPropertyListParser.ParseDouble(bytes);
+                        doubleValue = double.Parse(text);
                         longValue = (long)Math.Round(doubleValue);
                         break;
                     }
@@ -103,36 +122,34 @@ namespace Claunia.PropertyList
         {
             if (text == null)
                 throw new ArgumentException("The given string is null and cannot be parsed as number.");
-            try
+
+            long l;
+            double d;
+
+            if (long.TryParse(text, out l))
             {
-                long l = long.Parse(text);
                 doubleValue = longValue = l;
                 type = INTEGER;
             }
-            catch (Exception)
+            else if (double.TryParse(text, out d))
             {
-                try
+                doubleValue = d;
+                longValue = (long)Math.Round(doubleValue);
+                type = REAL;
+            }
+            else
+            {
+                bool isTrue = text.ToLower().Equals("true") || text.ToLower().Equals("yes");
+                bool isFalse = text.ToLower().Equals("false") || text.ToLower().Equals("no");
+
+                if (isTrue || isFalse)
                 {
-                    doubleValue = double.Parse(text, CultureInfo.InvariantCulture);
-                    longValue = (long)Math.Round(doubleValue);
-                    type = REAL;
+                    type = BOOLEAN;
+                    doubleValue = longValue = boolValue ? 1 : 0;
                 }
-                catch (Exception)
+                else
                 {
-                    try
-                    {
-                        boolValue = text.ToLower().Equals("true") || text.ToLower().Equals("yes");
-                        if (!boolValue && !(text.ToLower().Equals("false") || text.ToLower().Equals("no")))
-                        {
-                            throw new Exception("not a bool");
-                        }
-                        type = BOOLEAN;
-                        doubleValue = longValue = boolValue ? 1 : 0;
-                    }
-                    catch (Exception)
-                    {
-                        throw new ArgumentException("The given string neither represents a double, an int nor a bool value.");
-                    }
+                    throw new ArgumentException("The given string neither represents a double, an int nor a bool value.");
                 }
             }
         }

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -94,12 +94,12 @@ namespace Claunia.PropertyList
             {
                 case INTEGER:
                     {
-                        doubleValue = longValue = long.Parse(text);
+                        doubleValue = longValue = long.Parse(text, CultureInfo.InvariantCulture);
                         break;
                     }
                 case REAL:
                     {
-                        doubleValue = double.Parse(text);
+                        doubleValue = double.Parse(text, CultureInfo.InvariantCulture);
                         longValue = (long)Math.Round(doubleValue);
                         break;
                     }
@@ -126,12 +126,12 @@ namespace Claunia.PropertyList
             long l;
             double d;
 
-            if (long.TryParse(text, out l))
+            if (long.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out l))
             {
                 doubleValue = longValue = l;
                 type = INTEGER;
             }
-            else if (double.TryParse(text, out d))
+            else if (double.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out d))
             {
                 doubleValue = d;
                 longValue = (long)Math.Round(doubleValue);
@@ -139,8 +139,8 @@ namespace Claunia.PropertyList
             }
             else
             {
-                bool isTrue = text.ToLower().Equals("true") || text.ToLower().Equals("yes");
-                bool isFalse = text.ToLower().Equals("false") || text.ToLower().Equals("no");
+                bool isTrue = string.Equals(text, "true", StringComparison.InvariantCultureIgnoreCase) || string.Equals(text, "yes", StringComparison.InvariantCultureIgnoreCase);
+                bool isFalse = string.Equals(text, "false", StringComparison.InvariantCultureIgnoreCase) || string.Equals(text, "no", StringComparison.InvariantCultureIgnoreCase);
 
                 if (isTrue || isFalse)
                 {

--- a/plist-cil/XmlPropertyListParser.cs
+++ b/plist-cil/XmlPropertyListParser.cs
@@ -44,7 +44,11 @@ namespace Claunia.PropertyList
         public static NSObject Parse(FileInfo f)
         {
             XmlDocument doc = new XmlDocument();
-            doc.Load(f.OpenRead());
+
+            using (Stream stream = f.OpenRead())
+            {
+                doc.Load(stream);
+            }
 
             return ParseDocument(doc);
         }
@@ -153,9 +157,9 @@ namespace Claunia.PropertyList
             if (n.Name.Equals("false"))
                 return new NSNumber(false);
             if (n.Name.Equals("integer"))
-                return new NSNumber(GetNodeTextContents(n));
+                return new NSNumber(GetNodeTextContents(n), NSNumber.INTEGER);
             if (n.Name.Equals("real"))
-                return new NSNumber(GetNodeTextContents(n));
+                return new NSNumber(GetNodeTextContents(n), NSNumber.REAL);
             if (n.Name.Equals("string"))
                 return new NSString(GetNodeTextContents(n));
             if (n.Name.Equals("data"))


### PR DESCRIPTION
This PR:
- Fixes an issue where the original type of `NSNumber` (integer vs real) was lost when an integer value was stored in a real field (e.g. `<real>10</real>` would roundtrip as an integer)
- Uses the `TryParse` methods instead of `try`/`catch` logic in the `NSNumber(string)` constructor 

Hope it helps!