### PR TITLE
Fix recursive call in NSArray.GetEnumerator

### DIFF
--- a/plist-cil.test/NSArrayTests.cs
+++ b/plist-cil.test/NSArrayTests.cs
@@ -69,5 +69,28 @@ namespace plistcil.test
 
             Assert.AreEqual(0, array.Count);
         }
+
+        /// <summary>
+        /// Tests the <see cref="NSArray.GetEnumerator"/> method.
+        /// </summary>
+        [Test]
+        public void EnumeratorTest()
+        {
+            NSArray array = new NSArray();
+            array.Add(0);
+            array.Add(1);
+
+            var enumerator = array.GetEnumerator();
+
+            Assert.IsNull(enumerator.Current);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual(new NSNumber(0), enumerator.Current);
+
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual(new NSNumber(1), enumerator.Current);
+
+            Assert.IsFalse(enumerator.MoveNext());
+        }
     }
 }

--- a/plist-cil/NSArray.IList.cs
+++ b/plist-cil/NSArray.IList.cs
@@ -88,7 +88,7 @@ namespace Claunia.PropertyList
         /// <inheritdoc/>
         public IEnumerator<NSObject> GetEnumerator()
         {
-            return this.GetEnumerator();
+            return this.array.GetEnumerator();
         }
 
         public int IndexOf(object item)


### PR DESCRIPTION
Fixes endless recursion in `NSArray.GetEnumerator` (my bad, sorry) and adds a unit test to check for non-regression.