### PR TITLE
Fix date handling

### DIFF
--- a/plist-cil.test/NSDateTests.cs
+++ b/plist-cil.test/NSDateTests.cs
@@ -18,5 +18,15 @@ namespace plistcil.test
             var expected = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             Assert.AreEqual(expected, actual.Date.ToUniversalTime());
         }
+
+        [Test]
+        public static void MakeDateStringTest()
+        {
+            var date = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var expected = "2000-01-01T00:00:00Z";
+            var actual = NSDate.MakeDateString(date);
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/plist-cil.test/NSDateTests.cs
+++ b/plist-cil.test/NSDateTests.cs
@@ -1,0 +1,22 @@
+﻿using Claunia.PropertyList;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace plistcil.test
+{
+    [TestFixture]
+    public class NSDateTests
+    {
+        [Test]
+        public static void ConstructorTest()
+        {
+            var actual = new NSDate("2000-01-01T00:00:00Z");
+            var expected = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            Assert.AreEqual(expected, actual.Date.ToUniversalTime());
+        }
+    }
+}

--- a/plist-cil.test/ParseTest.cs
+++ b/plist-cil.test/ParseTest.cs
@@ -47,7 +47,7 @@ namespace plistcil.test
             Assert.True(d.Count == 5);
             Assert.True(((NSString)d.ObjectForKey("keyA")).ToString().Equals("valueA"));
             Assert.True(((NSString)d.ObjectForKey("key&B")).ToString().Equals("value&B"));
-            Assert.True(((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc)));
+            Assert.True(((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 10, 21, 30, DateTimeKind.Utc)));
             Assert.True(ArrayEquals(((NSData)d.ObjectForKey("data")).Bytes,
                 new byte[]{ 0x00, 0x00, 0x00, 0x04, 0x10, 0x41, 0x08, 0x20, (byte)0x82 }));
             NSArray a = (NSArray)d.ObjectForKey("array");

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="NSArrayTests.cs" />
     <Compile Include="NSNumberTests.cs" />
+    <Compile Include="NSDateTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ParseTest.cs" />
     <Compile Include="IssueTest.cs" />

--- a/plist-cil/NSDate.cs
+++ b/plist-cil/NSDate.cs
@@ -38,7 +38,9 @@ namespace Claunia.PropertyList
 
         static readonly DateTime EPOCH = new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        static readonly string sdfDefault = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+        // The datetime ends with 'Z', which indicates UTC time. To make sure .NET
+        // understands the 'Z' character as a timezone, specify the 'K' format string.
+        static readonly string sdfDefault = "yyyy-MM-dd'T'HH:mm:ssK";
         static readonly string sdfGnuStep = "yyyy-MM-dd HH:mm:ss zzz";
 
         static readonly System.Globalization.CultureInfo provider = System.Globalization.CultureInfo.InvariantCulture;

--- a/plist-cil/NSDate.cs
+++ b/plist-cil/NSDate.cs
@@ -69,9 +69,9 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <param name="date">The date which should be represented.</param>
         /// <returns>The string representation of the date.</returns>
-        static string MakeDateString(DateTime date)
+        public static string MakeDateString(DateTime date)
         {
-            return date.ToString(sdfDefault);
+            return date.ToUniversalTime().ToString(sdfDefault);
         }
 
         /// <summary>


### PR DESCRIPTION
Dates are always stored in UTC format in plist files, so make sure that:
- When reading them, the UTC time zone identifier ('Z') is parsed as such
- When writing them, the date is converted to UTC first