### PR TITLE
Fix issues with 0-length streams

### DIFF
--- a/plist-cil.test/PropertyListParserTests.cs
+++ b/plist-cil.test/PropertyListParserTests.cs
@@ -1,0 +1,20 @@
+﻿using Claunia.PropertyList;
+using NUnit.Framework;
+using System.IO;
+
+namespace plistcil.test
+{
+    [TestFixture]
+    public class PropertyListParserTests
+    {
+        [Test]
+        [ExpectedException(typeof(PropertyListFormatException))]
+        public static void ParseEmptyStreamTest()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                PropertyListParser.Parse(stream);
+            }
+        }
+    }
+}

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ParseTest.cs" />
     <Compile Include="IssueTest.cs" />
+    <Compile Include="PropertyListParserTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/plist-cil/PropertyListParser.cs
+++ b/plist-cil/PropertyListParser.cs
@@ -81,7 +81,7 @@ namespace Claunia.PropertyList
                 //Skip Unicode byte order mark (BOM)
                 offset += 3;
             }
-            while (offset < bytes.Length && bytes[offset] == ' ' || bytes[offset] == '\t' || bytes[offset] == '\r' || bytes[offset] == '\n' || bytes[offset] == '\f')
+            while (offset < bytes.Length && (bytes[offset] == ' ' || bytes[offset] == '\t' || bytes[offset] == '\r' || bytes[offset] == '\n' || bytes[offset] == '\f'))
             {
                 offset++;
             }
@@ -129,16 +129,11 @@ namespace Claunia.PropertyList
         /// <param name="fs">The Stream pointing to the data that should be stored in the array.</param>
         internal static byte[] ReadAll(Stream fs)
         {
-            MemoryStream outputStream = new MemoryStream();
-            byte[] buf = new byte[512];
-            int read = 512;
-            while (read == 512)
+            using (MemoryStream outputStream = new MemoryStream())
             {
-                read = fs.Read(buf, 0, 512);
-                if (read != -1)
-                    outputStream.Write(buf, 0, read);
+                fs.CopyTo(outputStream);
+                return outputStream.ToArray();
             }
-            return outputStream.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
When parsing a stream, it can happen that the stream is 0-length (or, more likely, that you're at the end of the stream by accident).

This would cause an index out of range exception in the `PropertyListParser`. This PR fixes that and also optimizes how ReadAll is implemented.

Hope it helps!