### PR TITLE
Always create a new file when writing to disk.

### DIFF
--- a/plist-cil/PropertyListParser.cs
+++ b/plist-cil/PropertyListParser.cs
@@ -219,7 +219,10 @@ namespace Claunia.PropertyList
             string parent = outFile.DirectoryName;
             if (!Directory.Exists(parent))
                 Directory.CreateDirectory(parent);
-            using (Stream fous = outFile.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite))
+
+            // Use Create here -- to make sure that when the updated file is shorter than
+            // the original file, no "obsolete" data is left at the end.
+            using (Stream fous = outFile.Open(FileMode.Create, FileAccess.ReadWrite))
             {
                 SaveAsXml(root, fous);
             }


### PR DESCRIPTION
Previously, plist-cil used `outFile.Open(FileMode.OpenOrCreate`. This had the side effect of, when the old file was larger than the new file, leaving some junk at the end of the file.

Using `FileMode.Create` fixes that (and if the file already exists, it is overwritten).

@claunia Would be great if you have some time to go over these pull requests :-)

Thanks!