### PR TITLE
Ignore DTD when reading XML PList documents

### DIFF
--- a/plist-cil/XmlPropertyListParser.cs
+++ b/plist-cil/XmlPropertyListParser.cs
@@ -72,7 +72,14 @@ namespace Claunia.PropertyList
         public static NSObject Parse(Stream str)
         {
             XmlDocument doc = new XmlDocument();
-            doc.Load(str);
+
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Ignore;
+
+            using (XmlReader reader = XmlReader.Create(str, settings))
+            {
+                doc.Load(reader);
+            }
 
             return ParseDocument(doc);
         }


### PR DESCRIPTION
I'm slightly surprised this wasn't an issue on .NET 4.6, but when trying to read a XmlDocument which contains a DTD definition (like the XML property lists), .NET Core will throw an exception unless you've instructed it to either ignore or validate DTD's.

This PR causes .NET to ignore them (they are not used anyway).