### PR TITLE
Binary compatibility with the Apple Plist format

### DIFF
--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -291,7 +291,7 @@ namespace Claunia.PropertyList
             {
                 idMap.Add(obj);
             }
-            else if(!this.ReuseObjectIds && obj is NSString && !IsSerializationPrimitive((NSString)obj))
+            else if (!this.ReuseObjectIds && obj is NSString && !IsSerializationPrimitive((NSString)obj))
             {
                 idMap.Add(obj);
             }
@@ -314,9 +314,9 @@ namespace Claunia.PropertyList
                 var first = idMap.OfType<UID>().First(v => NSObject.ArrayEquals(v.Bytes, uid.Bytes));
                 return idMap.IndexOf(first);
             }
-            else if (!this.ReuseObjectIds && obj is NSArray)
+            else if (!this.ReuseObjectIds && (obj is NSArray || (obj is NSString && !IsSerializationPrimitive((NSString)obj))))
             {
-                int index = 0;
+                int index = -1;
 
                 for (int i = 0; i < idMap.Count; i++)
                 {
@@ -325,6 +325,11 @@ namespace Claunia.PropertyList
                         index = i;
                         break;
                     }
+                }
+
+                if (index == -1)
+                {
+                    throw new InvalidOperationException();
                 }
 
                 return index;

--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -188,18 +188,18 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <param name="outStr">The output stream into which the binary property list will be written</param>
         /// <exception cref="IOException">If an error occured while writing to the stream</exception>
-        BinaryPropertyListWriter(Stream outStr)
+        public BinaryPropertyListWriter(Stream outStr)
         {
             outStream = outStr;
         }
 
-        BinaryPropertyListWriter(Stream outStr, int version)
+        public BinaryPropertyListWriter(Stream outStr, int version)
         {
             this.version = version;
             outStream = outStr;
         }
 
-        void Write(NSObject root)
+        public void Write(NSObject root)
         {
             // magic bytes
             Write(new[] { (byte)'b', (byte)'p', (byte)'l', (byte)'i', (byte)'s', (byte)'t' });
@@ -287,7 +287,7 @@ namespace Claunia.PropertyList
             // If binary compatibility with the Apple format is required,
             // UID, NSArray and NSString objects are assigned a new ID,
             // even if they already exist in the file.
-            if (!this.ReuseObjectIds && (obj is UID || obj is NSArray))
+            if (!this.ReuseObjectIds && (obj is UID || obj is NSNumber || obj is NSArray))
             {
                 idMap.Add(obj);
             }

--- a/plist-cil/NSDictionary.cs
+++ b/plist-cil/NSDictionary.cs
@@ -45,12 +45,17 @@ namespace Claunia.PropertyList
     {
         readonly Dictionary<string, NSObject> dict;
 
+        // Maps the keys in this dictionary to their NSString equivalent. Makes sure the NSString
+        // object remains constant accross calls to AssignIDs and ToBinary
+        readonly Dictionary<string, NSString> keys;
+
         /// <summary>
         /// Creates a new empty NSDictionary.
         /// </summary>
         public NSDictionary()
         {
             dict = new Dictionary<string, NSObject>();
+            keys = new Dictionary<string, NSString>();
         }
 
         /// <summary>
@@ -366,7 +371,7 @@ namespace Claunia.PropertyList
 
             foreach (KeyValuePair<string, NSObject> entry in dict)
             {
-                new NSString(entry.Key).AssignIDs(outPlist);
+                keys[entry.Key].AssignIDs(outPlist);
             }
 
             foreach (KeyValuePair<string, NSObject> entry in dict)
@@ -380,7 +385,7 @@ namespace Claunia.PropertyList
             outPlist.WriteIntHeader(0xD, dict.Count);
             foreach (KeyValuePair<String, NSObject> entry in dict)
             {
-                outPlist.WriteID(outPlist.GetID(new NSString(entry.Key)));
+                outPlist.WriteID(outPlist.GetID(keys[entry.Key]));
             }
             foreach (KeyValuePair<String, NSObject> entry in dict)
             {
@@ -488,6 +493,7 @@ namespace Claunia.PropertyList
         public void Add(string key, NSObject value)
         {
             dict.Add(key, value);
+            keys.Add(key, new NSString(key));
         }
 
         /// <summary>
@@ -516,6 +522,7 @@ namespace Claunia.PropertyList
         /// <param name="key">Key.</param>
         public bool Remove(string key)
         {
+            keys.Remove(key);
             return dict.Remove(key);
         }
 
@@ -534,7 +541,7 @@ namespace Claunia.PropertyList
         /// Gets or sets the <see cref="Claunia.PropertyList.NSObject"/> at the specified index.
         /// </summary>
         /// <param name="index">Index.</param>
-        public NSObject this [string index]
+        public NSObject this[string index]
         {
             get
             {
@@ -542,6 +549,11 @@ namespace Claunia.PropertyList
             }
             set
             {
+                if (!keys.ContainsKey(index))
+                {
+                    keys.Add(index, new NSString(index));
+                }
+
                 dict[index] = value;
             }
         }
@@ -579,6 +591,7 @@ namespace Claunia.PropertyList
         /// <param name="item">Item.</param>
         public void Add(KeyValuePair<string, NSObject> item)
         {
+            keys.Add(item.Key, new NSString(item.Key));
             dict.Add(item.Key, item.Value);
         }
 
@@ -587,6 +600,7 @@ namespace Claunia.PropertyList
         /// </summary>
         public void Clear()
         {
+            keys.Clear();
             dict.Clear();
         }
 
@@ -618,6 +632,7 @@ namespace Claunia.PropertyList
         /// <returns><c>true</c> if successfully removed, <c>false</c> if not, or if item is not in current instance.</returns>
         public bool Remove(KeyValuePair<string, NSObject> item)
         {
+            keys.Remove(item.Key);
             return dict.Remove(item.Key);
         }
 


### PR DESCRIPTION
We use plist-cil to implement one of Apple's protocols, and we strive to get binary compatibility. That is, we generate the exact same value on disk as the macOS tools do.

We've noticed that plist-cil tries to re-use object IDs in a property list: if you add the same object twice, the `BinaryPropertyListWriter` will add it once to the property list file and re-use the same ID.

Unfortunately, we hit a scenario where we need to write same value twice to the file, with different IDs.

This PR implements that. Because it would be a pitty to loose the optimization, we've added a `ReuseObjectIds` property which can be used to control this behavior.