### PR TITLE
Support NETStandard 1.3, 1.6

### DIFF
--- a/plist-cil/BinaryPropertyListParser.cs
+++ b/plist-cil/BinaryPropertyListParser.cs
@@ -23,6 +23,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.IO;
 
@@ -378,7 +379,7 @@ namespace Claunia.PropertyList
                     }
                 default:
                     {
-                        Console.WriteLine("WARNING: The given binary property list contains an object of unknown type (" + objType + ")");
+                        Debug.WriteLine("WARNING: The given binary property list contains an object of unknown type (" + objType + ")");
                         break;
                     }
             }
@@ -401,7 +402,7 @@ namespace Claunia.PropertyList
                 int intType = (int_type & 0xF0) >> 4;
                 if (intType != 0x1)
                 {
-                    Console.WriteLine("BinaryPropertyListParser: Length integer has an unexpected type" + intType + ". Attempting to parse anyway...");
+                    Debug.WriteLine("BinaryPropertyListParser: Length integer has an unexpected type" + intType + ". Attempting to parse anyway...");
                 }
                 int intInfo = int_type & 0x0F;
                 int intLength = (int)Math.Pow(2, intInfo);

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net40</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.3;netstandard1.6;net40;net45</TargetFrameworks>
     <Version>1.15</Version>
     <Authors>Natalia Portillo</Authors>
     <Company>Claunia.com</Company>
@@ -18,6 +18,7 @@
     <AssemblyOriginatorKeyFile>plist-cil.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -28,8 +29,8 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <DefineConstants>NETCOREAPP1_0;NETCORE</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.6'">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp1.0|AnyCPU'">
@@ -40,11 +41,27 @@
     <DocumentationFile>bin\Release\net40\plist-cil.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45'">
+    <Reference Include="System" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds support for NETStandard 1.3 and 1.6; the current version of plist-cil supports NETCoreApp which is slightly different.

It also adds net45 as an explicit target (because the reference assemblies for net45 are structured differently  ).

With these 4 PRs, I think I've captured all of the changes in our fork relative to claunia/plist-cil. So if they get merged, I think we can take CoreCompat.plist-cil offline. Cool!