### PR TITLE
Migrate to xUnit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ build_script:
   - cmd: cd plist-cil
   - cmd: dotnet restore
   - cmd: dotnet build -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
+  - cmd: dotnet test plist-cil.test\plist-cil.test.csproj
 
 on_success:
   - cmd: dotnet pack -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%

--- a/plist-cil.sln
+++ b/plist-cil.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26206.0
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{25B9F55C-9830-4526-9539-949838B09EAC}"
 	ProjectSection(SolutionItems) = preProject
@@ -24,28 +24,28 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x64.ActiveCfg = Debug|x64
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x64.Build.0 = Debug|x64
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x86.ActiveCfg = Debug|x86
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x86.Build.0 = Debug|x86
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Debug|x86.Build.0 = Debug|Any CPU
 		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x64.ActiveCfg = Release|x64
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x64.Build.0 = Release|x64
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x86.ActiveCfg = Release|x86
-		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x86.Build.0 = Release|x86
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x64.Build.0 = Release|Any CPU
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A906AEB-BDE0-4356-8114-064F80596C7D}.Release|x86.Build.0 = Release|Any CPU
 		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x64.ActiveCfg = Debug|x64
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x64.Build.0 = Debug|x64
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x86.ActiveCfg = Debug|x86
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x86.Build.0 = Debug|x86
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x64.Build.0 = Debug|Any CPU
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Debug|x86.Build.0 = Debug|Any CPU
 		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x64.ActiveCfg = Release|x64
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x64.Build.0 = Release|x64
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x86.ActiveCfg = Release|x86
-		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x86.Build.0 = Release|x86
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x64.ActiveCfg = Release|Any CPU
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x64.Build.0 = Release|Any CPU
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x86.ActiveCfg = Release|Any CPU
+		{17124CCE-32F1-4FD6-8703-32235BDEEEDC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -24,22 +24,21 @@
 // SOFTWARE.
 using System;
 using System.IO;
-using NUnit.Framework;
+using Xunit;
 using Claunia.PropertyList;
 
 namespace plistcil.test
 {
-    [TestFixture]
     public static class IssueTest
     {
-        [Test]
+        [Fact]
         public static void TestIssue4()
         {
             NSDictionary d = (NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue4.plist"));
             Assert.True(((NSString)d.ObjectForKey("Device Name")).ToString().Equals("Kid\u2019s iPhone"));
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue7()
         {
             // also a test for issue 12
@@ -50,14 +49,14 @@ namespace plistcil.test
             Assert.True(x.Equals(y));
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue16()
         {
             float x = ((NSNumber)PropertyListParser.Parse(new FileInfo("test-files/issue16.plist"))).floatValue();
             Assert.True(x == (float)2.71828);
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue18()
         {
             NSNumber x = new NSNumber(-999);
@@ -66,14 +65,14 @@ namespace plistcil.test
             Assert.True(x.Equals(y));
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue21()
         {
             String x = ((NSString)PropertyListParser.Parse(new FileInfo("test-files/issue21.plist"))).ToString();
             Assert.True(x.Equals("Lot&s of &persand&s and other escapable \"\'<>€ characters"));
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue22()
         {
             NSDictionary x1 = ((NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue22-emoji.plist")));
@@ -96,7 +95,7 @@ namespace plistcil.test
             Assert.True(emojiString.Equals(y2.ObjectForKey("emojiString").ToString()));
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue30()
         {
             #pragma warning disable 219
@@ -104,7 +103,7 @@ namespace plistcil.test
             #pragma warning restore 219
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue33()
         {
             #pragma warning disable 219
@@ -112,7 +111,7 @@ namespace plistcil.test
             #pragma warning restore 219
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue38()
         {
             NSDictionary dict = (NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue33.pbxproj"));
@@ -120,33 +119,33 @@ namespace plistcil.test
             Assert.True(fileRef.Equals(new NSString("65541A9B16D13B8C00A968D5")));
         }
 
-        [Test]
+        [Fact]
         public static void TestIssue49()
         {
             NSDictionary dict = (NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue49.plist"));
-            Assert.AreEqual(0, dict.Count);
+            Assert.Equal(0, dict.Count);
         }
 
-        [Test]
+        [Fact]
         public static void TestRealInResourceRule()
         {
             NSDictionary dict = (NSDictionary)XmlPropertyListParser.Parse(new FileInfo("test-files/ResourceRules.plist"));
-            Assert.AreEqual(1, dict.Count);
-            Assert.IsTrue(dict.ContainsKey("weight"));
+            Assert.Equal(1, dict.Count);
+            Assert.True(dict.ContainsKey("weight"));
 
             var weight = dict["weight"].ToObject();
-            Assert.IsInstanceOf<double>(weight);
-            Assert.AreEqual(10d, (double)weight);
+            Assert.IsType<double>(weight);
+            Assert.Equal(10d, (double)weight);
         }
 
-        [Test]
+        [Fact]
         public static void RoundtripTest()
         {
             var expected = File.ReadAllText(@"test-files\Roundtrip.plist");
             var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files\Roundtrip.plist"));
             var actual = value.ToXmlPropertyList();
 
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/plist-cil.test/NSArrayTests.cs
+++ b/plist-cil.test/NSArrayTests.cs
@@ -1,5 +1,5 @@
 ﻿using Claunia.PropertyList;
-using NUnit.Framework;
+using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,41 +8,40 @@ using System.Threading.Tasks;
 
 namespace plistcil.test
 {
-    [TestFixture]
     public class NSArrayTests
     {
         /// <summary>
         /// Tests the addition of a .NET object to the NSArray
         /// </summary>
-        [Test]
+        [Fact]
         public void AddAndContainsObjectTest()
         {
             NSArray array = new NSArray();
             array.Add(1);
 
-            Assert.IsTrue(array.Contains(1));
-            Assert.IsFalse(array.Contains(2));
+            Assert.True(array.Contains(1));
+            Assert.False(array.Contains(2));
         }
 
         /// <summary>
         /// Tests the <see cref="NSArray.IndexOf(object)"/> method for .NET objects.
         /// </summary>
-        [Test]
+        [Fact]
         public void IndexOfTest()
         {
             NSArray array = new NSArray();
             array.Add(1);
             array.Add("test");
 
-            Assert.AreEqual(0, array.IndexOf(1));
-            Assert.AreEqual(1, array.IndexOf("test"));
+            Assert.Equal(0, array.IndexOf(1));
+            Assert.Equal(1, array.IndexOf("test"));
         }
 
         /// <summary>
         /// Tests the <see cref="NSArray.Insert(int, object)"/> method for a 
         /// .NET object.
         /// </summary>
-        [Test]
+        [Fact]
         public void InsertTest()
         {
             NSArray array = new NSArray();
@@ -52,28 +51,28 @@ namespace plistcil.test
 
             array.Insert(1, "test");
 
-            Assert.AreEqual(4, array.Count);
-            Assert.AreEqual("test", array.ObjectAtIndex(1).ToObject());
+            Assert.Equal(4, array.Count);
+            Assert.Equal("test", array.ObjectAtIndex(1).ToObject());
         }
 
         /// <summary>
         /// Tests the <see cref="NSArray.Remove(object)"/> method for a .NET object.
         /// </summary>
-        [Test]
+        [Fact]
         public void RemoveTest()
         {
             NSArray array = new NSArray();
             array.Add(0);
-            Assert.IsFalse(array.Remove((object)1));
-            Assert.IsTrue(array.Remove((object)0));
+            Assert.False(array.Remove((object)1));
+            Assert.True(array.Remove((object)0));
 
-            Assert.AreEqual(0, array.Count);
+            Assert.Equal(0, array.Count);
         }
 
         /// <summary>
         /// Tests the <see cref="NSArray.GetEnumerator"/> method.
         /// </summary>
-        [Test]
+        [Fact]
         public void EnumeratorTest()
         {
             NSArray array = new NSArray();
@@ -82,15 +81,15 @@ namespace plistcil.test
 
             var enumerator = array.GetEnumerator();
 
-            Assert.IsNull(enumerator.Current);
+            Assert.Null(enumerator.Current);
 
-            Assert.IsTrue(enumerator.MoveNext());
-            Assert.AreEqual(new NSNumber(0), enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(new NSNumber(0), enumerator.Current);
 
-            Assert.IsTrue(enumerator.MoveNext());
-            Assert.AreEqual(new NSNumber(1), enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(new NSNumber(1), enumerator.Current);
 
-            Assert.IsFalse(enumerator.MoveNext());
+            Assert.False(enumerator.MoveNext());
         }
     }
 }

--- a/plist-cil.test/NSDateTests.cs
+++ b/plist-cil.test/NSDateTests.cs
@@ -1,5 +1,5 @@
 ﻿using Claunia.PropertyList;
-using NUnit.Framework;
+using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,25 +8,24 @@ using System.Threading.Tasks;
 
 namespace plistcil.test
 {
-    [TestFixture]
     public class NSDateTests
     {
-        [Test]
+        [Fact]
         public static void ConstructorTest()
         {
             var actual = new NSDate("2000-01-01T00:00:00Z");
             var expected = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            Assert.AreEqual(expected, actual.Date.ToUniversalTime());
+            Assert.Equal(expected, actual.Date.ToUniversalTime());
         }
 
-        [Test]
+        [Fact]
         public static void MakeDateStringTest()
         {
             var date = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             var expected = "2000-01-01T00:00:00Z";
             var actual = NSDate.MakeDateString(date);
 
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/plist-cil.test/NSNumberTests.cs
+++ b/plist-cil.test/NSNumberTests.cs
@@ -1,5 +1,5 @@
 ﻿using Claunia.PropertyList;
-using NUnit.Framework;
+using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,15 +10,14 @@ using System.Threading.Tasks;
 
 namespace plistcil.test
 {
-    [TestFixture]
     public class NSNumberTests
     {
-        [Test]
+        [Fact]
         public static void NSNumberConstructorTest()
         {
             var number = new NSNumber("10032936613", NSNumber.INTEGER);
-            Assert.AreEqual(NSNumber.INTEGER, number.GetNSNumberType());
-            Assert.AreEqual(10032936613, number.ToObject());
+            Assert.Equal(NSNumber.INTEGER, number.GetNSNumberType());
+            Assert.Equal(10032936613, number.ToObject());
         }
 
         // The tests below make sure the numbers are being parsed correctly, and do not depend on the culture info
@@ -28,49 +27,49 @@ namespace plistcil.test
         // <real>7200.000000</real>
 
 #if !NETCORE
-        [Test]
-        [SetCulture("en-US")]
+        [Fact]
+        [UseCulture("en-US")]
         public static void ParseNumberEnTest()
         {
             var number = new NSNumber("7200.000001");
-            Assert.IsTrue(number.isReal());
-            Assert.AreEqual(7200.000001d, number.ToDouble());
+            Assert.True(number.isReal());
+            Assert.Equal(7200.000001d, number.ToDouble());
         }
 
-        [Test]
-        [SetCulture("nl-BE")]
+        [Fact]
+        [UseCulture("nl-BE")]
         public static void ParseNumberNlTest()
         {
             // As seen in a real property list:
             // <key>TimeZoneOffsetFromUTC</key>
             // <real>7200.000000</real>
             var number = new NSNumber("7200.000001");
-            Assert.IsTrue(number.isReal());
-            Assert.AreEqual(7200.000001d, number.ToDouble());
+            Assert.True(number.isReal());
+            Assert.Equal(7200.000001d, number.ToDouble());
         }
 
-        [Test]
-        [SetCulture("en-US")]
+        [Fact]
+        [UseCulture("en-US")]
         public static void ParseNumberEnTest2()
         {
             // As seen in a real property list:
             // <key>TimeZoneOffsetFromUTC</key>
             // <real>7200.000000</real>
             var number = new NSNumber("7200.000000", NSNumber.REAL);
-            Assert.IsTrue(number.isReal());
-            Assert.AreEqual(7200d, number.ToDouble());
+            Assert.True(number.isReal());
+            Assert.Equal(7200d, number.ToDouble());
         }
 
-        [Test]
-        [SetCulture("nl-BE")]
+        [Fact]
+        [UseCulture("nl-BE")]
         public static void ParseNumberNlTest2()
         {
             // As seen in a real property list:
             // <key>TimeZoneOffsetFromUTC</key>
             // <real>7200.000000</real>
             var number = new NSNumber("7200.000000", NSNumber.REAL);
-            Assert.IsTrue(number.isReal());
-            Assert.AreEqual(7200d, number.ToDouble());
+            Assert.True(number.isReal());
+            Assert.Equal(7200d, number.ToDouble());
         }
 #endif
     }

--- a/plist-cil.test/ParseTest.cs
+++ b/plist-cil.test/ParseTest.cs
@@ -24,19 +24,18 @@
 // SOFTWARE.
 using System;
 using System.IO;
-using NUnit.Framework;
+using Xunit;
 using Claunia.PropertyList;
 using System.Collections.Generic;
 
 namespace plistcil.test
 {
-    [TestFixture]
     public static class ParseTest
     {
         /**
      * Test the xml reader/writer
      */
-        [Test]
+        [Fact]
         public static void TestXml()
         {
             // Parse an example plist file
@@ -66,7 +65,7 @@ namespace plistcil.test
         /**
      *  Test the binary reader/writer.
      */
-        [Test]
+        [Fact]
         public static void TestBinary()
         {
             NSObject x = PropertyListParser.Parse(new FileInfo("test-files/test1.plist"));
@@ -82,7 +81,7 @@ namespace plistcil.test
      *  NSSets are not yet supported in reading/writing, as binary property list format v1+ is required.
      */
         /*
-        [Test]
+        [Fact]
         public static void TestSet()
         {
             NSSet s = new NSSet();
@@ -104,7 +103,7 @@ namespace plistcil.test
             Assert.True(ParsedRoot.Equals(dict));
         }*/
 
-        [Test]
+        [Fact]
         public static void TestASCII()
         {
             NSObject x = PropertyListParser.Parse(new FileInfo("test-files/test1-ascii.plist"));
@@ -116,7 +115,7 @@ namespace plistcil.test
             var actualDate = (NSDate)d.ObjectForKey("date");
             var expectedDate = new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc).ToLocalTime();
 
-            Assert.AreEqual(actualDate.Date, expectedDate);
+            Assert.Equal(actualDate.Date, expectedDate);
             Assert.True(ArrayEquals(((NSData)d.ObjectForKey("data")).Bytes,
                 new byte[]{ 0x00, 0x00, 0x00, 0x04, 0x10, 0x41, 0x08, 0x20, (byte)0x82 }));
             NSArray a = (NSArray)d.ObjectForKey("array");
@@ -127,7 +126,7 @@ namespace plistcil.test
             Assert.True(a.ObjectAtIndex(3).Equals(new NSString("3.14159")));
         }
 
-        [Test]
+        [Fact]
         public static void TestGnuStepASCII()
         {
             NSObject x = PropertyListParser.Parse(new FileInfo("test-files/test1-ascii-gnustep.plist"));
@@ -146,7 +145,7 @@ namespace plistcil.test
             Assert.True(a.ObjectAtIndex(3).Equals(new NSNumber(3.14159)));
         }
 
-        [Test]
+        [Fact]
         public static void TestASCIIWriting()
         {
             FileInfo inf = new FileInfo("test-files/test1.plist");
@@ -162,7 +161,7 @@ namespace plistcil.test
             Assert.True(y.Equals(z));
         }
 
-        [Test]
+        [Fact]
         public static void TestGnuStepASCIIWriting()
         {
             FileInfo inf = new FileInfo("test-files/test1.plist");
@@ -173,7 +172,7 @@ namespace plistcil.test
             Assert.True(x.Equals(y));
         }
 
-        [Test]
+        [Fact]
         public static void TestWrap()
         {
             bool bl = true;

--- a/plist-cil.test/PropertyListParserTests.cs
+++ b/plist-cil.test/PropertyListParserTests.cs
@@ -1,16 +1,15 @@
 ﻿using Claunia.PropertyList;
-using NUnit.Framework;
+using Xunit;
 using System.IO;
 
 namespace plistcil.test
 {
-    [TestFixture]
     public class PropertyListParserTests
     {
-        [Test]
+        [Fact]
         public static void ParseEmptyStreamTest()
         {
-            Assert.Throws<PropertyListFormatException>(new TestDelegate(ParseEmptyStreamTestDelegate));
+            Assert.Throws<PropertyListFormatException>(() => ParseEmptyStreamTestDelegate());
         }
 
         static void ParseEmptyStreamTestDelegate()

--- a/plist-cil.test/UseCultureAttribute.cs
+++ b/plist-cil.test/UseCultureAttribute.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+/// <summary>
+/// Apply this attribute to your test method to replace the
+/// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+/// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public class UseCultureAttribute : BeforeAfterTestAttribute
+{
+    readonly Lazy<CultureInfo> culture;
+    readonly Lazy<CultureInfo> uiCulture;
+
+    CultureInfo originalCulture;
+    CultureInfo originalUICulture;
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <remarks>
+    /// <para>
+    /// This constructor overload uses <paramref name="culture" /> for both
+    /// <see cref="Culture" /> and <see cref="UICulture" />.
+    /// </para>
+    /// </remarks>
+    public UseCultureAttribute(string culture)
+        : this(culture, culture) { }
+
+    /// <summary>
+    /// Replaces the culture and UI culture of the current thread with
+    /// <paramref name="culture" /> and <paramref name="uiCulture" />
+    /// </summary>
+    /// <param name="culture">The name of the culture.</param>
+    /// <param name="uiCulture">The name of the UI culture.</param>
+    public UseCultureAttribute(string culture, string uiCulture)
+    {
+        this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
+        this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture));
+    }
+
+    /// <summary>
+    /// Gets the culture.
+    /// </summary>
+    public CultureInfo Culture { get { return culture.Value; } }
+
+    /// <summary>
+    /// Gets the UI culture.
+    /// </summary>
+    public CultureInfo UICulture { get { return uiCulture.Value; } }
+
+    /// <summary>
+    /// Stores the current <see cref="Thread.CurrentPrincipal" />
+    /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+    /// and replaces them with the new cultures defined in the constructor.
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void Before(MethodInfo methodUnderTest)
+    {
+#if NETCORE
+        originalCulture = CultureInfo.CurrentCulture;
+        originalUICulture = CultureInfo.CurrentUICulture;
+
+        CultureInfo.CurrentCulture = Culture;
+        CultureInfo.CurrentUICulture = Culture;
+#else
+        originalCulture = Thread.CurrentThread.CurrentCulture;
+        originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+        Thread.CurrentThread.CurrentCulture = Culture;
+        Thread.CurrentThread.CurrentUICulture = UICulture;
+#endif
+    }
+
+    /// <summary>
+    /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test</param>
+    public override void After(MethodInfo methodUnderTest)
+    {
+#if NETCORE
+        CultureInfo.CurrentCulture = originalCulture;
+        CultureInfo.CurrentUICulture = originalUICulture;
+#else
+        Thread.CurrentThread.CurrentCulture = originalCulture;
+        Thread.CurrentThread.CurrentUICulture = originalUICulture;
+#endif
+    }
+}

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net40</TargetFrameworks>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
@@ -93,6 +96,10 @@
     <None Include="test-files\Roundtrip.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/plist-cil/XmlPropertyListParser.cs
+++ b/plist-cil/XmlPropertyListParser.cs
@@ -45,9 +45,12 @@ namespace Claunia.PropertyList
         {
             XmlDocument doc = new XmlDocument();
 
+            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+
             using (Stream stream = f.OpenRead())
+            using (XmlReader reader = XmlReader.Create(stream, settings))
             {
-                doc.Load(stream);
+                doc.Load(reader);
             }
 
             return ParseDocument(doc);


### PR DESCRIPTION
Migrates the test to xUnit instead of NUnit. When I build the solution, the tests now show up in the Test Explorer window in Visual Studio, and I can also run the tests from within VS.