### PR TITLE
Add ParseString overloads to the [Xml, ASCII]PropertyListParser

### DIFF
--- a/plist-cil/ASCIIPropertyListParser.cs
+++ b/plist-cil/ASCIIPropertyListParser.cs
@@ -92,7 +92,18 @@ namespace Claunia.PropertyList
         /// <exception cref="FormatException">When an error occurs during parsing.</exception>
         public static NSObject Parse(byte[] bytes)
         {
-            ASCIIPropertyListParser parser = new ASCIIPropertyListParser(Encoding.UTF8.GetString(bytes).ToCharArray());
+            return ParseString(Encoding.UTF8.GetString(bytes));
+        }
+
+        /// <summary>
+        /// Parses an ASCII property list from a string.
+        /// </summary>
+        /// <param name="value">The ASCII property list data.</param>
+        /// <returns>The root object of the property list. This is usually a NSDictionary but can also be a NSArray.</returns>
+        /// <exception cref="FormatException">When an error occurs during parsing.</exception>
+        public static NSObject ParseString(string value)
+        {
+            ASCIIPropertyListParser parser = new ASCIIPropertyListParser(value.ToCharArray());
             return parser.Parse();
         }
 

--- a/plist-cil/XmlPropertyListParser.cs
+++ b/plist-cil/XmlPropertyListParser.cs
@@ -88,6 +88,23 @@ namespace Claunia.PropertyList
         }
 
         /// <summary>
+        /// Parses a XML property list from a string.
+        /// </summary>
+        /// <param name="value">The string pointing to the property list's data.</param>
+        /// <returns>The root object of the property list. This is usually a NSDictionary but can also be a NSArray.</returns>
+        public static NSObject ParseString(string value)
+        {
+            XmlDocument doc = new XmlDocument();
+
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Ignore;
+
+            doc.LoadXml(value);
+
+            return ParseDocument(doc);
+        }
+
+        /// <summary>
         /// Parses the XML document by generating the appropriate NSObjects for each XML node.
         /// </summary>
         /// <returns>The root NSObject of the property list contained in the XML document.</returns>


### PR DESCRIPTION
The XML and ASCII property list parsers allow you to parse byte arrays, streams, files,... but not individual strings.

I often find myself having to parse a property list from a string, so I've added a `ParseString` method to both classes.