### PR TITLE
Fix XML serialization of binary values

### DIFF
--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -164,8 +164,8 @@ namespace plistcil.test
         [Fact]
         public static void RoundtripDataTest()
         {
-            var expected = File.ReadAllText(@"test-files\RoundtripBinary.plist");
-            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files\RoundtripBinary.plist"));
+            var expected = File.ReadAllText(@"test-files/RoundtripBinary.plist");
+            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files/RoundtripBinary.plist"));
             var actual = value.ToXmlPropertyList();
 
             Assert.Equal(expected, actual, false, true);

--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -157,6 +157,19 @@ namespace plistcil.test
 
             Assert.Equal(expected, actual, false, true);
         }
+
+        /// <summary>
+        /// Makes sure that binary data is line-wrapped correctly when being serialized.
+        /// </summary>
+        [Fact]
+        public static void RoundtripDataTest()
+        {
+            var expected = File.ReadAllText(@"test-files\RoundtripBinary.plist");
+            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files\RoundtripBinary.plist"));
+            var actual = value.ToXmlPropertyList();
+
+            Assert.Equal(expected, actual, false, true);
+        }
     }
 }
 

--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -159,7 +159,8 @@ namespace plistcil.test
         }
 
         /// <summary>
-        /// Makes sure that binary data is line-wrapped correctly when being serialized.
+        /// Makes sure that binary data is line-wrapped correctly when being serialized, in a scenario
+        /// where the binary data is not indented (no leading whitespace).
         /// </summary>
         [Fact]
         public static void RoundtripDataTest()
@@ -168,7 +169,21 @@ namespace plistcil.test
             var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files/RoundtripBinary.plist"));
             var actual = value.ToXmlPropertyList();
 
-            Assert.Equal(expected, actual, false, true);
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+        }
+
+        /// <summary>
+        /// Makes sure that binary data is line-wrapped correctly when being serialized, in a scenario
+        /// where the binary data is indented.
+        /// </summary>
+        [Fact]
+        public static void RoundtripDataTest2()
+        {
+            var expected = File.ReadAllText(@"test-files/RoundtripBinaryIndentation.plist");
+            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files/RoundtripBinaryIndentation.plist"));
+            var actual = value.ToXmlPropertyList();
+
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -103,6 +103,9 @@
     <None Include="test-files\RoundtripReal.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="test-files\RoundtripBinary.plist">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -112,4 +112,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="test-files\RoundtripBinaryIndentation.plist">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/plist-cil.test/test-files/RoundtripBinary.plist
+++ b/plist-cil.test/test-files/RoundtripBinary.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<data>
+MjAxMy0wMi0wMiAyMDoxNjo0MiBHTVQ6IGhhbmRsZV9tZXNzYWdlOiBBbmQgeW91IHdp
+bGwga25vdyBteSBuYW1lIGlzIHRoZSBMb3JkIHdoZW4gSSBsYXkgbXkgdmVuZ2VhbmNl
+IHVwb24gdGhlZS4=
+</data>
+</plist>

--- a/plist-cil.test/test-files/RoundtripBinaryIndentation.plist
+++ b/plist-cil.test/test-files/RoundtripBinaryIndentation.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keyA</key>
+	<data>
+	MjAxMy0wMi0wMiAyMDoxNjo0MiBHTVQ6IGhhbmRsZV9tZXNzYWdlOiBBbmQgeW91IHdp
+	bGwga25vdyBteSBuYW1lIGlzIHRoZSBMb3JkIHdoZW4gSSBsYXkgbXkgdmVuZ2VhbmNl
+	IHVwb24gdGhlZS4=
+	</data>
+</dict>
+</plist>

--- a/plist-cil/NSData.cs
+++ b/plist-cil/NSData.cs
@@ -35,6 +35,9 @@ namespace Claunia.PropertyList
     /// @author Natalia Portillo
     public class NSData : NSObject
     {
+        // In the XML property list format, the base-64 encoded data is split across multiple lines.
+        // Each line contains 68 characters.
+        private const int DataLineLength = 68;
         readonly byte[] bytes;
 
         /// <summary>
@@ -157,8 +160,12 @@ namespace Claunia.PropertyList
             foreach (string line in base64.Split('\n'))
             {
                 Indent(xml, level);
-                xml.Append(line);
-                xml.Append(NSObject.NEWLINE);
+
+                for (int offset = 0; offset < base64.Length; offset += DataLineLength)
+                {
+                    xml.Append(line.Substring(offset, Math.Min(DataLineLength, line.Length - offset)));
+                    xml.Append(NSObject.NEWLINE);
+                }
             }
             Indent(xml, level);
             xml.Append("</data>");

--- a/plist-cil/NSData.cs
+++ b/plist-cil/NSData.cs
@@ -159,10 +159,9 @@ namespace Claunia.PropertyList
             string base64 = GetBase64EncodedData();
             foreach (string line in base64.Split('\n'))
             {
-                Indent(xml, level);
-
                 for (int offset = 0; offset < base64.Length; offset += DataLineLength)
                 {
+                    Indent(xml, level);
                     xml.Append(line.Substring(offset, Math.Min(DataLineLength, line.Length - offset)));
                     xml.Append(NSObject.NEWLINE);
                 }


### PR DESCRIPTION
When serializing binary data to XML property lists, the base64 representation of the data is split across multiple lines, like this:

```xml
<data>
MjAxMy0wMi0wMiAyMDoxNjo0MiBHTVQ6IGhhbmRsZV9tZXNzYWdlOiBBbmQgeW91IHdp
bGwga25vdyBteSBuYW1lIGlzIHRoZSBMb3JkIHdoZW4gSSBsYXkgbXkgdmVuZ2VhbmNl
IHVwb24gdGhlZS4=
</data>
```

This PR makes plist-cil behave the same way.