### PR TITLE
Fix roundtrip/serialization of real with > 5 digits

### DIFF
--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -151,8 +151,8 @@ namespace plistcil.test
         [Fact]
         public static void RoundtripRealTest()
         {
-            var expected = File.ReadAllText(@"test-files\RoundtripReal.plist");
-            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files\RoundtripReal.plist"));
+            var expected = File.ReadAllText(@"test-files/RoundtripReal.plist");
+            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files/RoundtripReal.plist"));
             var actual = value.ToXmlPropertyList();
 
             Assert.Equal(expected, actual, false, true);

--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -147,6 +147,16 @@ namespace plistcil.test
 
             Assert.Equal(expected, actual, false, true);
         }
+
+        [Fact]
+        public static void RoundtripRealTest()
+        {
+            var expected = File.ReadAllText(@"test-files\RoundtripReal.plist");
+            var value = XmlPropertyListParser.Parse(new FileInfo(@"test-files\RoundtripReal.plist"));
+            var actual = value.ToXmlPropertyList();
+
+            Assert.Equal(expected, actual, false, true);
+        }
     }
 }
 

--- a/plist-cil.test/NSNumberTests.cs
+++ b/plist-cil.test/NSNumberTests.cs
@@ -20,6 +20,13 @@ namespace plistcil.test
             Assert.Equal(10032936613, number.ToObject());
         }
 
+        [Fact]
+        public static void NSNumberWithDecimalTest()
+        {
+            var number = new NSNumber("1360155352.748765", NSNumber.REAL);
+            Assert.Equal("1360155352.748765", number.ToString());
+        }
+
         // The tests below make sure the numbers are being parsed correctly, and do not depend on the culture info
         // being set. Especially, decimal point may vary between cultures and we don't want to take a dependency on that
         // The value being used comes seen in a real property list:

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -100,6 +100,9 @@
     <None Include="test-files\Roundtrip.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="test-files\RoundtripReal.plist">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/plist-cil.test/test-files/RoundtripReal.plist
+++ b/plist-cil.test/test-files/RoundtripReal.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<real>1360155352.748765</real>
+</plist>

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -331,7 +331,7 @@ namespace Claunia.PropertyList
                     }
                 case REAL:
                     {
-                        return ToDouble().ToString(CultureInfo.InvariantCulture);
+                        return ToDouble().ToString("G17", CultureInfo.InvariantCulture);
                     }
                 case BOOLEAN:
                     {
@@ -369,7 +369,9 @@ namespace Claunia.PropertyList
                         }
                         else
                         {
-                            xml.Append(ToDouble().ToString(CultureInfo.InvariantCulture));
+                            // ToString() can truncate the decimals, so use "G17". See
+                            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-round-trip-r-format-specifier
+                            xml.Append(ToDouble().ToString("G17", CultureInfo.InvariantCulture));
                         }
 
                         xml.Append("</real>");

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -331,7 +331,7 @@ namespace Claunia.PropertyList
                     }
                 case REAL:
                     {
-                        return ToDouble().ToString("G17", CultureInfo.InvariantCulture);
+                        return ToDouble().ToString("R", CultureInfo.InvariantCulture);
                     }
                 case BOOLEAN:
                     {
@@ -369,9 +369,9 @@ namespace Claunia.PropertyList
                         }
                         else
                         {
-                            // ToString() can truncate the decimals, so use "G17". See
+                            // ToString() can truncate the decimals, so use "R". See
                             // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-round-trip-r-format-specifier
-                            xml.Append(ToDouble().ToString("G17", CultureInfo.InvariantCulture));
+                            xml.Append(ToDouble().ToString("R", CultureInfo.InvariantCulture));
                         }
 
                         xml.Append("</real>");


### PR DESCRIPTION
Values such as "0.748765" would be truncated to "0.74876", use `.ToString("G17")` to keep all digits in the string repesentation.