### PR TITLE
Fix build warnings

### DIFF
--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -35,7 +35,7 @@ namespace plistcil.test
         public static void TestIssue4()
         {
             NSDictionary d = (NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue4.plist"));
-            Assert.True(((NSString)d.ObjectForKey("Device Name")).ToString().Equals("Kid\u2019s iPhone"));
+            Assert.Equal("Kid\u2019s iPhone", ((NSString)d.ObjectForKey("Device Name")).ToString());
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace plistcil.test
         public static void TestIssue21()
         {
             String x = ((NSString)PropertyListParser.Parse(new FileInfo("test-files/issue21.plist"))).ToString();
-            Assert.True(x.Equals("Lot&s of &persand&s and other escapable \"\'<>€ characters"));
+            Assert.Equal("Lot&s of &persand&s and other escapable \"\'<>€ characters", x);
         }
 
         [Fact]
@@ -89,10 +89,10 @@ namespace plistcil.test
 
             String emojiString = "Test Test, \uD83D\uDE30\u2754\uD83D\uDC4D\uD83D\uDC4E\uD83D\uDD25";
 
-            Assert.True(emojiString.Equals(x1.ObjectForKey("emojiString").ToString()));
-            Assert.True(emojiString.Equals(x2.ObjectForKey("emojiString").ToString()));
-            Assert.True(emojiString.Equals(y1.ObjectForKey("emojiString").ToString()));
-            Assert.True(emojiString.Equals(y2.ObjectForKey("emojiString").ToString()));
+            Assert.Equal(emojiString, x1.ObjectForKey("emojiString").ToString());
+            Assert.Equal(emojiString, x2.ObjectForKey("emojiString").ToString());
+            Assert.Equal(emojiString, y1.ObjectForKey("emojiString").ToString());
+            Assert.Equal(emojiString, y2.ObjectForKey("emojiString").ToString());
         }
 
         [Fact(Skip = "Support for property lists with a root element which is not plist is not implemented")]
@@ -123,14 +123,14 @@ namespace plistcil.test
         public static void TestIssue49()
         {
             NSDictionary dict = (NSDictionary)PropertyListParser.Parse(new FileInfo("test-files/issue49.plist"));
-            Assert.Equal(0, dict.Count);
+            Assert.Empty(dict);
         }
 
         [Fact]
         public static void TestRealInResourceRule()
         {
             NSDictionary dict = (NSDictionary)XmlPropertyListParser.Parse(new FileInfo("test-files/ResourceRules.plist"));
-            Assert.Equal(1, dict.Count);
+            Assert.Single(dict);
             Assert.True(dict.ContainsKey("weight"));
 
             var weight = dict["weight"].ToObject();

--- a/plist-cil.test/NSArrayTests.cs
+++ b/plist-cil.test/NSArrayTests.cs
@@ -52,7 +52,7 @@ namespace plistcil.test
             array.Insert(1, "test");
 
             Assert.Equal(4, array.Count);
-            Assert.Equal("test", array.ObjectAtIndex(1).ToObject());
+            Assert.Equal("test", array[1].ToObject());
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace plistcil.test
             Assert.False(array.Remove((object)1));
             Assert.True(array.Remove((object)0));
 
-            Assert.Equal(0, array.Count);
+            Assert.Empty(array);
         }
 
         /// <summary>

--- a/plist-cil.test/ParseTest.cs
+++ b/plist-cil.test/ParseTest.cs
@@ -44,18 +44,18 @@ namespace plistcil.test
             // check the data in it
             NSDictionary d = (NSDictionary)x;
             Assert.True(d.Count == 5);
-            Assert.True(((NSString)d.ObjectForKey("keyA")).ToString().Equals("valueA"));
-            Assert.True(((NSString)d.ObjectForKey("key&B")).ToString().Equals("value&B"));
+            Assert.Equal("valueA", ((NSString)d.ObjectForKey("keyA")).ToString());
+            Assert.Equal("value&B", ((NSString)d.ObjectForKey("key&B")).ToString());
             Assert.True(((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 10, 21, 30, DateTimeKind.Utc)) ||
                 ((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc)));
             Assert.True(ArrayEquals(((NSData)d.ObjectForKey("data")).Bytes,
                 new byte[]{ 0x00, 0x00, 0x00, 0x04, 0x10, 0x41, 0x08, 0x20, (byte)0x82 }));
             NSArray a = (NSArray)d.ObjectForKey("array");
             Assert.True(a.Count == 4);
-            Assert.True(a.ObjectAtIndex(0).Equals(new NSNumber(true)));
-            Assert.True(a.ObjectAtIndex(1).Equals(new NSNumber(false)));
-            Assert.True(a.ObjectAtIndex(2).Equals(new NSNumber(87)));
-            Assert.True(a.ObjectAtIndex(3).Equals(new NSNumber(3.14159)));
+            Assert.True(a[0].Equals(new NSNumber(true)));
+            Assert.True(a[1].Equals(new NSNumber(false)));
+            Assert.True(a[2].Equals(new NSNumber(87)));
+            Assert.True(a[3].Equals(new NSNumber(3.14159)));
 
             // read/write it, make sure we get the same thing
             PropertyListParser.SaveAsXml(x, new FileInfo("test-files/out-testXml.plist"));
@@ -110,8 +110,8 @@ namespace plistcil.test
             NSObject x = PropertyListParser.Parse(new FileInfo("test-files/test1-ascii.plist"));
             NSDictionary d = (NSDictionary)x;
             Assert.True(d.Count == 5);
-            Assert.True(((NSString)d.ObjectForKey("keyA")).ToString().Equals("valueA"));
-            Assert.True(((NSString)d.ObjectForKey("key&B")).ToString().Equals("value&B"));
+            Assert.Equal("valueA", ((NSString)d.ObjectForKey("keyA")).ToString());
+            Assert.Equal("value&B", ((NSString)d.ObjectForKey("key&B")).ToString());
 
             var actualDate = (NSDate)d.ObjectForKey("date");
             var expectedDate = new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc).ToLocalTime();
@@ -121,10 +121,10 @@ namespace plistcil.test
                 new byte[]{ 0x00, 0x00, 0x00, 0x04, 0x10, 0x41, 0x08, 0x20, (byte)0x82 }));
             NSArray a = (NSArray)d.ObjectForKey("array");
             Assert.True(a.Count == 4);
-            Assert.True(a.ObjectAtIndex(0).Equals(new NSString("YES")));
-            Assert.True(a.ObjectAtIndex(1).Equals(new NSString("NO")));
-            Assert.True(a.ObjectAtIndex(2).Equals(new NSString("87")));
-            Assert.True(a.ObjectAtIndex(3).Equals(new NSString("3.14159")));
+            Assert.True(a[0].Equals(new NSString("YES")));
+            Assert.True(a[1].Equals(new NSString("NO")));
+            Assert.True(a[2].Equals(new NSString("87")));
+            Assert.True(a[3].Equals(new NSString("3.14159")));
         }
 
         [Fact]
@@ -133,17 +133,17 @@ namespace plistcil.test
             NSObject x = PropertyListParser.Parse(new FileInfo("test-files/test1-ascii-gnustep.plist"));
             NSDictionary d = (NSDictionary)x;
             Assert.True(d.Count == 5);
-            Assert.True(((NSString)d.ObjectForKey("keyA")).ToString().Equals("valueA"));
-            Assert.True(((NSString)d.ObjectForKey("key&B")).ToString().Equals("value&B"));
+            Assert.Equal("valueA", ((NSString)d.ObjectForKey("keyA")).ToString());
+            Assert.Equal("value&B", ((NSString)d.ObjectForKey("key&B")).ToString());
             Assert.True(((NSDate)d.ObjectForKey("date")).Date.Equals(new DateTime(2011, 11, 28, 9, 21, 30, DateTimeKind.Utc).ToLocalTime()));
             Assert.True(ArrayEquals(((NSData)d.ObjectForKey("data")).Bytes,
                 new byte[]{ 0x00, 0x00, 0x00, 0x04, 0x10, 0x41, 0x08, 0x20, (byte)0x82 }));
             NSArray a = (NSArray)d.ObjectForKey("array");
             Assert.True(a.Count == 4);
-            Assert.True(a.ObjectAtIndex(0).Equals(new NSNumber(true)));
-            Assert.True(a.ObjectAtIndex(1).Equals(new NSNumber(false)));
-            Assert.True(a.ObjectAtIndex(2).Equals(new NSNumber(87)));
-            Assert.True(a.ObjectAtIndex(3).Equals(new NSNumber(3.14159)));
+            Assert.True(a[0].Equals(new NSNumber(true)));
+            Assert.True(a[1].Equals(new NSNumber(false)));
+            Assert.True(a[2].Equals(new NSNumber(87)));
+            Assert.True(a[3].Equals(new NSNumber(3.14159)));
         }
 
         [Fact]
@@ -229,7 +229,7 @@ namespace plistcil.test
 
             WrappedO = NSObject.Wrap((Object)strg);
             Assert.True(WrappedO.GetType().Equals(typeof(NSString)));
-            Assert.True(((string)WrappedO.ToObject()).Equals(strg));
+            Assert.Equal(((string)WrappedO.ToObject()), strg);
 
             WrappedO = NSObject.Wrap((Object)bytes);
             Assert.True(WrappedO.GetType().Equals(typeof(NSData)));

--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -102,7 +102,7 @@ namespace Claunia.PropertyList
             else if (root is NSArray)
             {
                 NSArray array = (NSArray)root;
-                foreach (NSObject o in array.GetArray())
+                foreach (NSObject o in array)
                 {
                     int v = GetMinimumRequiredVersion(o);
                     if (v > minVersion)

--- a/plist-cil/NSArray.cs
+++ b/plist-cil/NSArray.cs
@@ -212,14 +212,14 @@ namespace Claunia.PropertyList
         {
             if (obj.GetType().Equals(typeof(NSArray)))
             {
-                return ArrayEquals(((NSArray)obj).GetArray(), this.GetArray());
+                return ArrayEquals(((NSArray)obj), this);
             }
             else
             {
                 NSObject nso = NSObject.Wrap(obj);
                 if (nso.GetType().Equals(typeof(NSArray)))
                 {
-                    return ArrayEquals(((NSArray)nso).GetArray(), this.GetArray());
+                    return ArrayEquals(((NSArray)nso), this);
                 }
             }
             return false;
@@ -390,7 +390,7 @@ namespace Claunia.PropertyList
                 return false;
 
             for (int i = 0; i < array.Count; i++)
-                if (!array[i].Equals(((NSArray)obj).ObjectAtIndex(i)))
+                if (!array[i].Equals(((NSArray)obj)[i]))
                     return false;
 
             return true;

--- a/plist-cil/NSObject.cs
+++ b/plist-cil/NSObject.cs
@@ -23,10 +23,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
-using System.Text;
 using System.Collections.Generic;
-using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace Claunia.PropertyList
 {
@@ -372,13 +372,13 @@ namespace Claunia.PropertyList
         {
             if (this is NSArray)
             {
-                NSObject[] arrayA = ((NSArray)this).GetArray();
-                Object[] arrayB = new Object[arrayA.Length];
-                for (int i = 0; i < arrayA.Length; i++)
+                var nsArray = (NSArray)this;
+                object[] array = new object[nsArray.Count];
+                for (int i = 0; i < nsArray.Count; i++)
                 {
-                    arrayB[i] = arrayA[i].ToObject();
+                    array[i] = nsArray[i].ToObject();
                 }
-                return arrayB;
+                return array;
             }
             if (this is NSDictionary)
             {
@@ -451,11 +451,11 @@ namespace Claunia.PropertyList
             return false;
         }
 
-        internal static bool ArrayEquals(NSObject[] arrayA, NSObject[] arrayB)
+        internal static bool ArrayEquals(IList<NSObject> arrayA, IList<NSObject> arrayB)
         {
-            if (arrayA.Length == arrayB.Length)
+            if (arrayA.Count == arrayB.Count)
             {
-                for (int i = 0; i < arrayA.Length; i++)
+                for (int i = 0; i < arrayA.Count; i++)
                 {
                     if (arrayA[i] != arrayB[i])
                     {


### PR DESCRIPTION
There were a bunch of build warnings, coming from either methods marked as obsolete or the xUnit analyzers. This PR fixes those warnings.