### PR TITLE
Add support for Span<byte>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 solution: plist-cil.sln
 mono:
  - none
-dotnet: 2.1.200
+dotnet: 2.1.300
 dist: trusty
 script:
  - dotnet build -c Release

--- a/plist-cil/ASCIIPropertyListParser.cs
+++ b/plist-cil/ASCIIPropertyListParser.cs
@@ -92,7 +92,35 @@ namespace Claunia.PropertyList
         /// <exception cref="FormatException">When an error occurs during parsing.</exception>
         public static NSObject Parse(byte[] bytes)
         {
+            return Parse(bytes.AsSpan());
+        }
+
+        /// <summary>
+        /// Parses an ASCII property list from a byte array.
+        /// </summary>
+        /// <param name="bytes">The ASCII property list data.</param>
+        /// <param name="count">The offset at which to start reading the property list.</param>
+        /// <param name="offset">The length of the property list.</param>
+        /// <returns>The root object of the property list. This is usually a NSDictionary but can also be a NSArray.</returns>
+        /// <exception cref="FormatException">When an error occurs during parsing.</exception>
+        public static NSObject Parse(byte[] bytes, int offset, int count)
+        {
+            return Parse(bytes.AsSpan(offset, count));
+        }
+
+        /// <summary>
+        /// Parses an ASCII property list from a byte span.
+        /// </summary>
+        /// <param name="bytes">The ASCII property list data.</param>
+        /// <returns>The root object of the property list. This is usually a NSDictionary but can also be a NSArray.</returns>
+        /// <exception cref="FormatException">When an error occurs during parsing.</exception>
+        public static NSObject Parse(ReadOnlySpan<byte> bytes)
+        {
+#if NATIVE_SPAN
             return ParseString(Encoding.UTF8.GetString(bytes));
+#else
+            return ParseString(Encoding.UTF8.GetString(bytes.ToArray()));
+#endif
         }
 
         /// <summary>

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netstandard1.3;netstandard1.4;netstandard1.6;netcoreapp2.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <Version>1.16</Version>
     <Authors>Natalia Portillo</Authors>
     <Company>Claunia.com</Company>
@@ -12,22 +12,23 @@
     <RepositoryUrl>http://www.github.com/claunia/plist-cil</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>apple propertylist property list gnustep plist</PackageTags>
-    <PackageReleaseNotes>Added support for .NETStandard1.4.
-Enhanced binary compatibility with Apple.
-Correct opening of plists with unescaped UTF8 strings.
-Added support for parsing hex numbers.
-Added explicit casts for NSNumber, NSData, NSDate and NSString.
-Added examples to README.</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      Added support for .NETStandard1.4.
+      Enhanced binary compatibility with Apple.
+      Correct opening of plists with unescaped UTF8 strings.
+      Added support for parsing hex numbers.
+      Added explicit casts for NSNumber, NSData, NSDate and NSString.
+      Added examples to README.
+    </PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>plist-cil.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <TargetFrameworks>$(TargetFrameworks);net45;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -42,36 +43,19 @@ Added examples to README.</PackageReleaseNotes>
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp1.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netcoreapp1.0\plist-cil.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);NATIVE_SPAN</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net40|AnyCPU'">
-    <DocumentationFile>bin\Release\net40\plist-cil.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
   </ItemGroup>
-  
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('netstandard'))">
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Globalization" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-    <PackageReference Include="System.Threading" Version="4.3.0" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+    <PackageReference Include="System.Memory" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;netcoreapp2.0;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <Version>1.16</Version>
     <Authors>Natalia Portillo</Authors>
     <Company>Claunia.com</Company>
@@ -52,6 +52,23 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard1.'))">
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;netcoreapp2.0;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.3;netstandard1.4;netstandard1.6;netcoreapp2.0;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <Version>1.16</Version>
     <Authors>Natalia Portillo</Authors>
     <Company>Claunia.com</Company>
@@ -54,7 +54,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard1.'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard1.')) Or $(TargetFramework.StartsWith('netcoreapp1.'))">
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Globalization" Version="4.3.0" />


### PR DESCRIPTION
We're doing a performance review of our application and are trying to make sure of the new `Span<byte>` and `ReadOnlySpan<byte>` types which are new in .NET land.

For plist-cil, working with `Span<byte>` opens a lot of opportunities:
- Allowing users to read data from a subset of an `byte[]` array (e.g. starting at index 10 and a length of 42), without having to copy that subset to a new array (which has a performance impact)
- Improving the performance of deserializing binary property lists.
- ...

This PR adds support for reading property lists form those types to plist-cil. 

It comes with a couple of drawbacks, though. That includes:
- dropping support for 'old' versions of .NET Core (`netstandard1.x` and `netcoreapp1.x`). It appears there's a big push to get everyone to use at least `netstandard2.0`, so that should be OK
- dropping support for .NET 4.0 (.NET 4.5 is still supported, though)
- adding a dependency on System.Memory for the .NET Framework versions

Supporting .NET Framework without adding a dependency on System.Memory and still adding support for `Span<byte>` would mean duplicating a lot of code, and I'm not sure it's worth it.

Would this be a problem for you?