### PR TITLE
Add unit tests for BinaryPropertyListParser, UID classes

### DIFF
--- a/plist-cil.test/BinaryPropertyListParserTests.cs
+++ b/plist-cil.test/BinaryPropertyListParserTests.cs
@@ -1,0 +1,36 @@
+﻿using Claunia.PropertyList;
+using Xunit;
+
+namespace plistcil.test
+{
+    public class BinaryPropertyListParserTests
+    {
+        [Theory]
+        [InlineData(new byte[] { 0x08 }, 0x08)]
+        [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07 }, 7)]
+        [InlineData(new byte[] { 0x00, 0x0e, 0x47, 0x7b }, 0x00000000000e477b)]
+        public void ParseUnsignedIntTest(byte[] binaryValue, int expectedValue)
+        {
+            Assert.Equal(expectedValue, BinaryPropertyListParser.ParseUnsignedInt(binaryValue));
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0x57 }, 0x57)]
+        [InlineData(new byte[] { 0x40, 0x2d, 0xf8, 0x4d }, 0x402df84d)]
+        [InlineData(new byte[] { 0x41, 0xb4, 0x83, 0x98, 0x2a, 0x00, 0x00, 0x00 }, 0x41b483982a000000)]
+        [InlineData(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfc, 0x19 }, unchecked((long)0xfffffffffffffc19))]
+        public void ParseLongTest(byte[] binaryValue, long expectedValue)
+        {
+            Assert.Equal(expectedValue, BinaryPropertyListParser.ParseLong(binaryValue));
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0x41, 0xb4, 0x83, 0x98, 0x2a, 0x00, 0x00, 0x00 }, 344168490)]
+        [InlineData(new byte[] { 0x40, 0x09, 0x21, 0xf9, 0xf0, 0x1b, 0x86, 0x6e }, 3.14159)]
+        [InlineData(new byte[] { 0x40, 0x2d, 0xf8, 0x4d }, 2.71828007698059)]
+        public void ParseDoubleTest(byte[] binaryValue, double expectedValue)
+        {
+            Assert.Equal(expectedValue, BinaryPropertyListParser.ParseDouble(binaryValue), 14);
+        }
+    }
+}

--- a/plist-cil.test/UIDTests.cs
+++ b/plist-cil.test/UIDTests.cs
@@ -1,0 +1,119 @@
+﻿using Claunia.PropertyList;
+using System.IO;
+using Xunit;
+
+namespace plistcil.test
+{
+    public class UIDTests
+    {
+        [Fact]
+        public void ByteUidTest()
+        {
+            var uid = new UID("byte", (byte)0xAB);
+            Assert.Equal(new byte[] { 0xAB }, uid.Bytes);
+            Assert.Equal("byte", uid.Name);
+        }
+
+        [Fact]
+        public void SByteUidTest()
+        {
+            var uid = new UID("sbyte", unchecked((sbyte)0xAB));
+            Assert.Equal(new byte[] { 0xAB }, uid.Bytes);
+            Assert.Equal("sbyte", uid.Name);
+        }
+
+        [Fact]
+        public void ShortUidTest()
+        {
+            var uid = new UID("short", unchecked((short)0xABCD));
+            Assert.Equal(new byte[] { 0xAB, 0xCD }, uid.Bytes);
+            Assert.Equal("short", uid.Name);
+        }
+
+        [Fact]
+        public void UShortUidTest()
+        {
+            var uid = new UID("ushort", 0xABCDu);
+            Assert.Equal(new byte[] { 0xAB, 0xCD }, uid.Bytes);
+            Assert.Equal("ushort", uid.Name);
+        }
+
+        [Fact]
+        public void UIntUidTest()
+        {
+            var uid = new UID("uint", 0xABCDEF00u);
+            Assert.Equal(new byte[] { 0xAB, 0xCD, 0xEF, 0x00 }, uid.Bytes);
+            Assert.Equal("uint", uid.Name);
+        }
+
+        [Fact]
+        public void IntUidTest()
+        {
+            var uid = new UID("int", 0xABCDEF00);
+            Assert.Equal(new byte[] { 0xAB, 0xCD, 0xEF, 0x00 }, uid.Bytes);
+            Assert.Equal("int", uid.Name);
+        }
+
+        [Fact]
+        public void ULongUidTest()
+        {
+            var uid = new UID("ulong", 0xABCDEF0000EFCDABu);
+            Assert.Equal(new byte[] { 0xAB, 0xCD, 0xEF, 0x00, 0x00, 0xEF, 0xCD, 0xAB }, uid.Bytes);
+            Assert.Equal("ulong", uid.Name);
+        }
+
+        [Fact]
+        public void LongUidTest()
+        {
+            var uid = new UID("int", 0xABCDEF0000EFCDAB);
+            Assert.Equal(new byte[] { 0xAB, 0xCD, 0xEF, 0x00, 0x00, 0xEF, 0xCD, 0xAB }, uid.Bytes);
+            Assert.Equal("int", uid.Name);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0xAB })]
+        [InlineData(new byte[] { 0xAB, 0xCD })]
+        [InlineData(new byte[] { 0xAB, 0xCD, 0xEF, 0xFE })]
+        [InlineData(new byte[] { 0xAB, 0xCD, 0xEF, 0xFE, 0xFE, 0xEF, 0xCD, 0xAB })]
+        [InlineData(new byte[] { 0x00 })]
+        [InlineData(new byte[] { 0x00, 0x00 })]
+        [InlineData(new byte[] { 0x00, 0xCD })]
+        [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(new byte[] { 0x00, 0x00, 0x00, 0xCD })]
+        [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })]
+        [InlineData(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCD })]
+        public void UidFromArrayTest(byte[] array)
+        {
+            var uid = new UID("array", array);
+            Assert.Equal(array, uid.Bytes);
+            Assert.Equal("array", uid.Name);
+        }
+
+        [Fact]
+        public void BinaryRoundTripTest()
+        {
+            var original = new UID("0", 0xabcd);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryPropertyListWriter.Write(stream, original);
+                stream.Position = 0;
+                var roundtrip = BinaryPropertyListParser.Parse(stream) as UID;
+                Assert.Equal(original, roundtrip);
+            }
+        }
+
+        [Fact]
+        public void XmlRoundTripTest()
+        {
+            var original = new UID("0", 0xabcd);
+
+            var plist = original.ToXmlPropertyList();
+
+            // UIDs don't exist in XML property lists, but they are represented as strings
+            // for compability purposes
+            var roundtrip = XmlPropertyListParser.ParseString(plist) as NSString;
+            Assert.Equal("0000abcd", roundtrip.ToObject());
+        }
+    }
+}

--- a/plist-cil.test/UIDTests.cs
+++ b/plist-cil.test/UIDTests.cs
@@ -99,7 +99,7 @@ namespace plistcil.test
                 BinaryPropertyListWriter.Write(stream, original);
                 stream.Position = 0;
                 var roundtrip = BinaryPropertyListParser.Parse(stream) as UID;
-                Assert.Equal(original, roundtrip);
+                Assert.Equal(original.Bytes, roundtrip.Bytes);
             }
         }
 


### PR DESCRIPTION
I wrote some unit tests for the `BinaryPropertyListParserTests` and `UID` classes as part of #38. I'm splitting them of in a separate PR to make it easier to review, and I guess these are straightforward to get merged 😄 .