### PR TITLE
Use Span.Slice instead of creating new arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
  - dotnet build -c Release
  - dotnet test plist-cil.test/plist-cil.test.csproj
  - dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
+ - git checkout master
+ - dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ build_script:
   - cmd: dotnet build -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - cmd: dotnet test plist-cil.test\plist-cil.test.csproj
   - cmd: dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
+  - cmd: git checkout master
+  - cmd: dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
 
 on_success:
   - cmd: dotnet pack plist-cil\plist-cil.csproj -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%

--- a/plist-cil/NSDate.cs
+++ b/plist-cil/NSDate.cs
@@ -90,7 +90,7 @@ namespace Claunia.PropertyList
         /// Creates a date from its binary representation.
         /// </summary>
         /// <param name="bytes">bytes The date bytes</param>
-        public NSDate(byte[] bytes)
+        public NSDate(ReadOnlySpan<byte> bytes)
         {
             //dates are 8 byte big-endian double, seconds since the epoch
             date = EPOCH.AddSeconds(BinaryPropertyListParser.ParseDouble(bytes));

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -69,7 +69,7 @@ namespace Claunia.PropertyList
         /// <param name="type">The type of number</param>
         /// <seealso cref="INTEGER"/>
         /// <seealso cref="REAL"/>
-        public NSNumber(byte[] bytes, int type)
+        public NSNumber(ReadOnlySpan<byte> bytes, int type)
         {
             switch (type)
             {

--- a/plist-cil/NSString.cs
+++ b/plist-cil/NSString.cs
@@ -42,10 +42,14 @@ namespace Claunia.PropertyList
         /// <param name="bytes">The binary representation.</param>
         /// <param name="encoding">The encoding of the binary representation, the name of a supported charset.</param>
         /// <exception cref="ArgumentException">The encoding charset is invalid or not supported by the underlying platform.</exception>
-        public NSString(byte[] bytes, String encoding)
+        public NSString(ReadOnlySpan<byte> bytes, String encoding)
         {
             Encoding enc = Encoding.GetEncoding(encoding);
+#if NATIVE_SPAN
             content = enc.GetString(bytes);
+#else
+            content = enc.GetString(bytes.ToArray());
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
A lot of code in the `BinaryPropertyListParser` works with sections of arrays. Instead of creating a new array and copying that data to the new array, we can now use `Span.Slice`,  which reduces a lot of allocations and improves performance.