### PR TITLE
Improve BinaryPropertyListWriter performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ script:
  - dotnet build -c Release
  - dotnet test plist-cil.test/plist-cil.test.csproj
  - dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
- - git checkout master
- - dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@ build_script:
   - cmd: dotnet build -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - cmd: dotnet test plist-cil.test\plist-cil.test.csproj
   - cmd: dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
-  - cmd: git checkout master
-  - cmd: dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
 
 on_success:
   - cmd: dotnet pack plist-cil\plist-cil.csproj -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%

--- a/plist-cil/BinaryPropertyListWriter.AddObjectEqualityComparer.cs
+++ b/plist-cil/BinaryPropertyListWriter.AddObjectEqualityComparer.cs
@@ -31,7 +31,20 @@ namespace Claunia.PropertyList
 
             public override int GetHashCode(NSObject obj)
             {
-                throw new System.NotImplementedException();
+                if (obj == null)
+                {
+                    return 0;
+                }
+
+                var s = obj as NSString;
+                if (s != null && BinaryPropertyListWriter.IsSerializationPrimitive(s))
+                {
+                    return s.Content.GetHashCode();
+                }
+                else
+                {
+                    return obj.GetHashCode();
+                }
             }
         }
     }

--- a/plist-cil/BinaryPropertyListWriter.GetObjectEqualityComparer.cs
+++ b/plist-cil/BinaryPropertyListWriter.GetObjectEqualityComparer.cs
@@ -37,7 +37,24 @@ namespace Claunia.PropertyList
 
             public override int GetHashCode(NSObject obj)
             {
-                throw new NotImplementedException();
+                if (obj == null)
+                {
+                    return 0;
+                }
+
+                var u = obj as UID;
+                if (u != null)
+                {
+                    return u.GetHashCode();
+                }
+
+                var s = obj as NSString;
+                if (s != null && BinaryPropertyListWriter.IsSerializationPrimitive(s))
+                {
+                    return s.Content.GetHashCode();
+                }
+
+                return obj.GetHashCode();
             }
         }
     }


### PR DESCRIPTION
This PR improves the performance of the BinaryPropertyListWriter by using a `Dictionary<NSObject, int>` to store the indices of binary objects instead of a `Collection<NSObject>`. It removes the need to do an `IndexOf`, which scans the entire list. That is a very expensive O(N) operation.

This results in a 97% performance improvement on Windows (i.e. 30 times as fast) and a 98% performance improvement on Linux.