### PR TITLE
BinaryPropertyListParser/Writer: Add extensibility points

### DIFF
--- a/plist-cil/BinaryPropertyListParser.cs
+++ b/plist-cil/BinaryPropertyListParser.cs
@@ -118,7 +118,7 @@ namespace Claunia.PropertyList
         /// <returns>The root object of the property list. This is usually a NSDictionary but can also be a NSArray.</returns>
         /// <param name="bytes">The binary property list's data.</param>
         /// <exception cref="PropertyListFormatException">When the property list's format could not be parsed.</exception>
-        NSObject DoParse(ReadOnlySpan<byte> bytes)
+        protected NSObject DoParse(ReadOnlySpan<byte> bytes)
         {
             if(bytes.Length < 8    || bytes[0] != 'b' || bytes[1] != 'p' || bytes[2] != 'l' || bytes[3] != 'i' ||
                bytes[4]     != 's' || bytes[5] != 't')
@@ -194,6 +194,11 @@ namespace Claunia.PropertyList
             return Parse(f.OpenRead());
         }
 
+        protected int GetOffset(int obj)
+        {
+            return this.offsetTable[obj];
+        }
+
         /// <summary>
         ///     Parses an object inside the currently parsed binary property list.
         ///     For the format specification check
@@ -205,7 +210,7 @@ namespace Claunia.PropertyList
         /// <returns>The parsed object.</returns>
         /// <param name="obj">The object ID.</param>
         /// <exception cref="PropertyListFormatException">When the property list's format could not be parsed.</exception>
-        NSObject ParseObject(ReadOnlySpan<byte> bytes, int obj)
+        protected virtual NSObject ParseObject(ReadOnlySpan<byte> bytes, int obj)
         {
             int  offset  = offsetTable[obj];
             byte type    = bytes[offset];

--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -62,13 +62,13 @@ namespace Claunia.PropertyList
         public const int VERSION_20 = 20;
 
         // map from object to its ID
-        readonly Dictionary<NSObject, int> idDict  = new Dictionary<NSObject, int>(new AddObjectEqualityComparer());
-        readonly Dictionary<NSObject, int> idDict2 = new Dictionary<NSObject, int>(new GetObjectEqualityComparer());
+        protected readonly Dictionary<NSObject, int> idDict  = new Dictionary<NSObject, int>(new AddObjectEqualityComparer());
+        protected readonly Dictionary<NSObject, int> idDict2 = new Dictionary<NSObject, int>(new GetObjectEqualityComparer());
 
         // # of bytes written so far
-        long count;
-        int  currentId;
-        int  idSizeInBytes;
+        private long   count;
+        protected int  currentId;
+        private int    idSizeInBytes;
 
         // raw output stream to result file
         Stream outStream;
@@ -89,6 +89,14 @@ namespace Claunia.PropertyList
         {
             this.version = version;
             outStream    = outStr;
+        }
+
+        public BinaryPropertyListWriter(Stream outStr, int version, IEqualityComparer<NSObject> addObjectEqualityComparer, IEqualityComparer<NSObject> getObjectEqualityComparer)
+        {
+            this.version = version;
+            outStream    = outStr;
+            idDict       = new Dictionary<NSObject, int>(addObjectEqualityComparer);
+            idDict2      = new Dictionary<NSObject, int>(getObjectEqualityComparer);
         }
 
         /// <summary>
@@ -273,7 +281,7 @@ namespace Claunia.PropertyList
             outStream.Flush();
         }
 
-        internal void AssignID(NSObject obj)
+        protected internal virtual void AssignID(NSObject obj)
         {
             if(ReuseObjectIds)
             {


### PR DESCRIPTION
I've spent some time today figuring out why the `BinaryPropertyListWriter` was generating slightly different data from what I expected.

To figure that out, did some debugging tricks like:
- Change the `EqualityComparer`s which are passed to the `BinaryPropertyListWriter`
- Dumping all IDs as they are being assigned in `AssignID`
- Adding some diagnostic code to `BinaryPropertyListParser` to get the index, offset and summary of all values in the binary property list,
- ...

In the end, my life would be easier if:
- I could just inherit from `BinaryPropertyListParser` and `BinaryPropertyListWriter` and override methods like `DoParse`. 
- I could pass a custom EqualityComparer to the `BinaryPropertyListWriter` when it's being created.

This PR makes some of the methods protected and adds a new constructor, just enough so that I can actually do that.

Hopefully this is OK with you.