### PR TITLE
Add UID.ToUInt64() method

### DIFF
--- a/plist-cil.test/UIDTests.cs
+++ b/plist-cil.test/UIDTests.cs
@@ -36,6 +36,7 @@ namespace plistcil.test
         {
             UID uid = new UID(0xAB);
             Assert.Equal(new byte[] {0xAB}, uid.Bytes);
+            Assert.Equal(0xABu, uid.ToUInt64());
         }
 
         [Fact]
@@ -43,6 +44,7 @@ namespace plistcil.test
         {
             UID uid = new UID(0xABCDEF00);
             Assert.Equal(new byte[] {0xAB, 0xCD, 0xEF, 0x00}, uid.Bytes);
+            Assert.Equal(0xABCDEF00, uid.ToUInt64());
         }
 
         [Fact]
@@ -50,6 +52,7 @@ namespace plistcil.test
         {
             UID uid = new UID(0xABCDEF0000EFCDAB);
             Assert.Equal(new byte[] {0xAB, 0xCD, 0xEF, 0x00, 0x00, 0xEF, 0xCD, 0xAB}, uid.Bytes);
+            Assert.Equal(0xABCDEF0000EFCDAB, uid.ToUInt64());
         }
 
         [Fact]
@@ -71,6 +74,7 @@ namespace plistcil.test
         {
             UID uid = new UID(0xABCDEF00u);
             Assert.Equal(new byte[] {0xAB, 0xCD, 0xEF, 0x00}, uid.Bytes);
+            Assert.Equal(0xABCDEF00u, uid.ToUInt64());
         }
 
         [Fact]
@@ -78,6 +82,7 @@ namespace plistcil.test
         {
             UID uid = new UID(0xABCDEF0000EFCDABu);
             Assert.Equal(new byte[] {0xAB, 0xCD, 0xEF, 0x00, 0x00, 0xEF, 0xCD, 0xAB}, uid.Bytes);
+            Assert.Equal(0xABCDEF0000EFCDABu, uid.ToUInt64());
         }
 
         [Fact]
@@ -85,6 +90,7 @@ namespace plistcil.test
         {
             UID uid = new UID(0xABCDu);
             Assert.Equal(new byte[] {0xAB, 0xCD}, uid.Bytes);
+            Assert.Equal(0xABCDu, uid.ToUInt64());
         }
 
         [Fact]

--- a/plist-cil/UID.cs
+++ b/plist-cil/UID.cs
@@ -333,5 +333,16 @@ namespace Claunia.PropertyList
         {
             return $"{value} (UID)";
         }
+
+        /// <summary>
+        /// Gets a <see cref="ulong"/> which represents this <see cref="UID"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="ulong"/> which represents this <see cref="UID"/>.
+        /// </returns>
+        public ulong ToUInt64()
+        {
+            return this.value;
+        }
     }
 }


### PR DESCRIPTION
Currenly to only way to get the value of a `UID` is to call `.Bytes`, but this allocates a new `byte[]` very time. That's a bit silly, as we store the value of this UID in the value field as a `ulong`.

This PR adds a `ToUInt64` method, which gives direct access to the value of the UID. It gives a performance improvement in some scenarios in my application (because we avoid creating a `byte[]` which needs to be garbage collected).