### PR TITLE
Use 1 << exp instead of Math.Pow(2, exp)

### DIFF
--- a/plist-cil/BinaryPropertyListParser.cs
+++ b/plist-cil/BinaryPropertyListParser.cs
@@ -268,13 +268,13 @@ namespace Claunia.PropertyList
                 case 0x1:
                 {
                     //integer
-                    int length = (int)Math.Pow(2, objInfo);
+                    int length = 1 << objInfo;
                     return new NSNumber(bytes.Slice(offset + 1, length), NSNumber.INTEGER);
                 }
                 case 0x2:
                 {
                     //real
-                    int length = (int)Math.Pow(2, objInfo);
+                    int length = 1 << objInfo;
                     return new NSNumber(bytes.Slice(offset + 1, length), NSNumber.REAL);
                 }
                 case 0x3:
@@ -427,7 +427,7 @@ namespace Claunia.PropertyList
                     Debug.WriteLine("BinaryPropertyListParser: Length integer has an unexpected type" + intType +
                                     ". Attempting to parse anyway...");
                 int intInfo   = int_type & 0x0F;
-                int intLength = (int)Math.Pow(2, intInfo);
+                int intLength = 1 << intInfo;
                 offsetValue = 2 + intLength;
                 if(intLength < 3) lengthValue = (int)ParseUnsignedInt(bytes.Slice(offset + 2, intLength));
                 else


### PR DESCRIPTION
`Math.Pow(double, double)` is a relatively expensive operation (since it can take an arbitrary exponent). For powers of two, byteshift operators are much faster.

Benchmark.NET can't actually measure the time it takes to do `1 << exp`, but `Math.Pow(2, exp)` takes about 40 nanoseconds. It was actually slow enough to show up in some of the performance traces we took.