### PR TITLE
Use Stream.WriteByte, and don't allocate a new byte array

### DIFF
--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -344,6 +344,7 @@ namespace Claunia.PropertyList
         internal void Write(int b)
         {
             outStream.WriteByte((byte)b);
+            count++;
         }
 
         internal void Write(byte[] bytes)

--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -343,10 +343,7 @@ namespace Claunia.PropertyList
 
         internal void Write(int b)
         {
-            byte[] bBytes = new byte[1];
-            bBytes[0] = (byte)b;
-            outStream.Write(bBytes, 0, 1);
-            count++;
+            outStream.WriteByte((byte)b);
         }
 
         internal void Write(byte[] bytes)


### PR DESCRIPTION
Stream has a `Stream.WriteByte` overload, so you don't need to create a new array just to write a single byte. Plus, throwaway arrays like this put pressure on the garbage collector.