### PR TITLE
Drop netstandard1.x and netcoreapp1.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,6 @@ build_script:
   - cmd: git checkout master
   - cmd: dotnet run --project plist-cil.benchmark/plist-cil.benchmark.csproj -c Release
 
-on_success:
-  - cmd: dotnet pack plist-cil\plist-cil.csproj -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
-
 artifacts:
   - path: "plist-cil\\bin\\Release\\plist-cil.*.nupkg"
   - path: "BenchmarkDotNet.Artifacts\\results\\*.*"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ on_success:
 
 artifacts:
   - path: "plist-cil\\bin\\Release\\plist-cil.*.nupkg"
-  - path: "plist-cil.benchmark\\BenchmarkDotNet.Artifacts\\results\\*.*"
+  - path: "BenchmarkDotNet.Artifacts\\results\\*.*"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 build_script:
   - cmd: dotnet build -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - cmd: dotnet test plist-cil.test\plist-cil.test.csproj

--- a/plist-cil/PropertyListException.cs
+++ b/plist-cil/PropertyListException.cs
@@ -25,9 +25,7 @@
 // SOFTWARE.
 
 using System;
-#if NET45
 using System.Runtime.Serialization;
-#endif
 
 namespace Claunia.PropertyList
 {
@@ -62,11 +60,9 @@ namespace Claunia.PropertyList
         /// </param>
         public PropertyListException(string message, Exception inner) : base(message, inner) { }
 
-        #if !NETCORE
         protected PropertyListException(SerializationInfo info, StreamingContext context) 
             : base(info, context)
         {
         }
-        #endif
     }
 }

--- a/plist-cil/PropertyListParser.cs
+++ b/plist-cil/PropertyListParser.cs
@@ -247,16 +247,8 @@ namespace Claunia.PropertyList
         /// <exception cref="IOException">When an error occurs during the writing process.</exception>
         public static void SaveAsXml(NSObject root, Stream outStream)
         {
-            #if NET40
-            // The StreamWriter constructor which takes a "leaveOpen" parameter is
-            // not available on .NET 4.0
-            StreamWriter w = new StreamWriter(outStream, Encoding.UTF8);
-            w.Write(root.ToXmlPropertyList());
-            w.Close();
-#else
             using(StreamWriter w = new StreamWriter(outStream, Encoding.UTF8, 1024, true))
                 w.Write(root.ToXmlPropertyList());
-            #endif
         }
 
         /// <summary>

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netstandard1.3;netstandard1.4;netstandard1.6;netcoreapp2.0;netstandard2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0;netstandard2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <VersionPrefix>2.1</VersionPrefix>
     <Authors>Natalia Portillo</Authors>
     <Company>Claunia.com</Company>
@@ -46,31 +46,7 @@ Use invariant culture to format NSDate.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="System" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard1.')) Or $(TargetFramework.StartsWith('netcoreapp1.'))">
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Globalization" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-    <PackageReference Include="System.Threading" Version="4.3.0" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">


### PR DESCRIPTION
Compiling plist-cil for all those different platforms takes some time, and I think most people who were on .NET Core 1.x now have moved to .NET Core 2.x.

It also simplifies the project file a bit.