### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ mono:
  - none
 dotnet: 2.2
 dist: bionic
+git:
+  depth: false
 script:
  - dotnet build -c Release
  - dotnet test plist-cil.test/plist-cil.test.csproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 solution: plist-cil.sln
 mono:
  - none
-dotnet: 2.1.300
+dotnet: 2.2
 dist: trusty
 script:
  - dotnet build -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ solution: plist-cil.sln
 mono:
  - none
 dotnet: 2.2
-dist: trusty
+dist: bionic
 script:
  - dotnet build -c Release
  - dotnet test plist-cil.test/plist-cil.test.csproj


### PR DESCRIPTION
This fixes the Travis build by:

* Updating the .NET Core version to 2.2
* Updating the Ubuntu dist to Bionic (the latest LTS release as of now). This was necessary because .NET Core 2.2 could not be installed on Trusty because of a [bug in dpkg].(https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627)
* Disabling the Git checkout depth, so the master branch can be checked out for benchmarking