### PR TITLE
Update XML representation of UIDs

### DIFF
--- a/plist-cil.test/UIDTests.cs
+++ b/plist-cil.test/UIDTests.cs
@@ -86,10 +86,11 @@ namespace plistcil.test
 
             string plist = original.ToXmlPropertyList();
 
-            // UIDs don't exist in XML property lists, but they are represented as strings
+            // UIDs don't exist in XML property lists, but they are represented as dictionaries
             // for compability purposes
-            NSString roundtrip = XmlPropertyListParser.ParseString(plist) as NSString;
-            Assert.Equal("abcd", roundtrip.ToObject());
+            var roundtrip = XmlPropertyListParser.ParseString(plist) as NSDictionary;
+            Assert.Single(roundtrip.Keys, "CF$UID");
+            Assert.Single(roundtrip.Values, new NSNumber(0xabcd));
         }
     }
 }

--- a/plist-cil/UID.cs
+++ b/plist-cil/UID.cs
@@ -148,19 +148,28 @@ namespace Claunia.PropertyList
         }
 
         /// <summary>
-        ///     There is no XML representation specified for UIDs.
-        ///     In this implementation UIDs are represented as strings in the XML output.
+        ///     UIDs are represented as dictionaries in XML property lists,
+        ///     where the key is always <c>CF$UID</c> and the value is the integer
+        ///     representation of the UID.
         /// </summary>
         /// <param name="xml">The xml StringBuilder</param>
         /// <param name="level">The indentation level</param>
         internal override void ToXml(StringBuilder xml, int level)
         {
             Indent(xml, level);
-            xml.Append("<string>");
-            Span<byte> bytes = stackalloc byte[ByteCount];
-            GetBytes(bytes);
-            foreach(byte b in bytes) xml.Append(string.Format("{0:x2}", b));
-            xml.Append("</string>");
+            xml.Append("<dict>");
+            xml.AppendLine();
+
+            Indent(xml, level + 1);
+            xml.Append("<key>CF$UID</key>");
+            xml.AppendLine();
+
+            Indent(xml, level + 1);
+            xml.Append($"<integer>{this.value}</integer>");
+            xml.AppendLine();
+
+            Indent(xml, level);
+            xml.Append("</dict>");
         }
 
         internal override void ToBinary(BinaryPropertyListWriter outPlist)


### PR DESCRIPTION
It turns out that UIDs are represented like this in XML:

```xml
<dict>
    <key>CF$UID</key>
    <integer>2</integer>
</dict>
```

There's not a lot of documentation, but:

- They appear in property lists used by the [Swift unit tests](https://github.com/apple/swift-corelibs-foundation/blob/2a5bc4d8a0b073532e60410682f5eb8f00144870/Tests/Foundation/Resources/NSKeyedUnarchiver-OrderedSetTest.plist)
- [Here's one blog entry describing the format](https://digitalinvestigation.wordpress.com/2012/04/04/geek-post-nskeyedarchiver-files-what-are-they-and-how-can-i-use-them/)
- [ Here's another document (see page 7) describing the format](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.190.762&rep=rep1&type=pdf)

This PR allows you to properly _serialize_ property lists which contain UID entries.

Deserializing is not implemented; you'd manually need to detect dictionaries with `CF$UID` keys and convert them to `UID`s.