### PR TITLE
XmlPropertyListParser: Support deserializing UID values

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 build_script:
   - cmd: dotnet build -c Release --version-suffix r%APPVEYOR_BUILD_NUMBER%
   - cmd: dotnet test plist-cil.test\plist-cil.test.csproj

--- a/plist-cil.test/UIDTests.cs
+++ b/plist-cil.test/UIDTests.cs
@@ -88,9 +88,8 @@ namespace plistcil.test
 
             // UIDs don't exist in XML property lists, but they are represented as dictionaries
             // for compability purposes
-            var roundtrip = XmlPropertyListParser.ParseString(plist) as NSDictionary;
-            Assert.Single(roundtrip.Keys, "CF$UID");
-            Assert.Single(roundtrip.Values, new NSNumber(0xabcd));
+            var roundtrip = XmlPropertyListParser.ParseString(plist) as UID;
+            Assert.Equal(0xabcdUL, roundtrip.ToUInt64());
         }
     }
 }

--- a/plist-cil/XmlPropertyListParser.cs
+++ b/plist-cil/XmlPropertyListParser.cs
@@ -147,19 +147,31 @@ namespace Claunia.PropertyList
         {
             if(n.Name.Equals("dict"))
             {
-                NSDictionary  dict     = new NSDictionary();
-                List<XmlNode> children = FilterElementNodes(n.ChildNodes);
-                for(int i = 0; i < children.Count; i += 2)
+                // Special case for UID values
+                if(n.ChildNodes.Count == 2
+                    && n.ChildNodes[0].Name == "key"
+                    && n.ChildNodes[0].InnerText == "CF$UID"
+                    && n.ChildNodes[1].Name == "integer"
+                    && uint.TryParse(n.ChildNodes[1].InnerText, out uint uidValue))
                 {
-                    XmlNode key = children[i];
-                    XmlNode val = children[i + 1];
-
-                    string keyString = GetNodeTextContents(key);
-
-                    dict.Add(keyString, ParseObject(val));
+                    return new UID(uidValue);
                 }
+                else
+                {
+                    NSDictionary  dict     = new NSDictionary();
+                    List<XmlNode> children = FilterElementNodes(n.ChildNodes);
+                    for(int i = 0; i < children.Count; i += 2)
+                    {
+                        XmlNode key = children[i];
+                        XmlNode val = children[i + 1];
 
-                return dict;
+                        string keyString = GetNodeTextContents(key);
+
+                        dict.Add(keyString, ParseObject(val));
+                    }
+
+                    return dict;
+                }
             }
 
             if(n.Name.Equals("array"))


### PR DESCRIPTION
Follow-up to #65, implementing the deserialization of UID values when reading XML property lists.

I'm not a huge fan of having to special-case deserializing `dict` nodes, but it appears the `if` statement is relatively inexpensive.