### PR TITLE
Add .NET 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 solution: plist-cil.sln
 mono:
  - none
-dotnet: 2.2
+dotnet: 5.0
 dist: bionic
 git:
   depth: false

--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ They originate from the NeXTSTEP programming environment and are now a basic par
 * Cocoa / NeXTSTEP / GNUstep ASCII
 
 ## Requirements
-.NET Framework 4.0, Mono or .NET Core.
-Targets .NET Framework 4.0, .NET Framework 4.5, .NET Standard 1.3, .NET Standard 1.4 and .NET Standard 1.6 so it should be compatible with Mono, Xamarin.iOS, Xamarin.Mac, UWP, etc.
-If you find an incompatibility, please create an issue.
+plist-cil targets:
+
+- .NET Framework 4.5,
+- .NET Standard 2.0
+- .NET Core 2.1
+- .NET Core 3.1.
+- .NET 5.0
+
+This means it should be compatible with Mono, Xamarin.iOS, Xamarin.Mac, UWP, etc. If you find an incompatibility, please create an issue.
 
 ## Download
 

--- a/plist-cil.benchmark/BinaryPropertyListParserBenchmarks.cs
+++ b/plist-cil.benchmark/BinaryPropertyListParserBenchmarks.cs
@@ -1,10 +1,10 @@
-﻿using System.IO;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using System.IO;
 
 namespace Claunia.PropertyList.Benchmark
 {
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
     [MemoryDiagnoser]
     public class BinaryPropertyListParserBenchmarks
     {

--- a/plist-cil.benchmark/BinaryPropertyListWriterBenchmarks.cs
+++ b/plist-cil.benchmark/BinaryPropertyListWriterBenchmarks.cs
@@ -1,9 +1,9 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
+using BenchmarkDotNet.Jobs;
 
 namespace Claunia.PropertyList.Benchmark
 {
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
     [MemoryDiagnoser]
     public class BinaryPropertyListWriterBenchmarks
     {

--- a/plist-cil.benchmark/plist-cil.benchmark.csproj
+++ b/plist-cil.benchmark/plist-cil.benchmark.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Claunia.PropertyList.Benchmark</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plist-cil.test/NSNumberTests.cs
+++ b/plist-cil.test/NSNumberTests.cs
@@ -110,8 +110,6 @@ namespace plistcil.test
         // The value being used comes seen in a real property list:
         // <key>TimeZoneOffsetFromUTC</key>
         // <real>7200.000000</real>
-
-        #if !NETCORE
         [Fact]
         [UseCulture("en-US")]
         public static void ParseNumberEnTest()
@@ -156,7 +154,6 @@ namespace plistcil.test
             Assert.True(number.isReal());
             Assert.Equal(7200d, number.ToDouble());
         }
-#endif
 
         public static IEnumerable<object[]> StringConstructorTestData()
         {

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <DefineConstants>NETCOREAPP1_0;NETCORE</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\plist-cil\plist-cil.csproj" />

--- a/plist-cil/BinaryPropertyListWriter.cs
+++ b/plist-cil/BinaryPropertyListWriter.cs
@@ -355,10 +355,10 @@ namespace Claunia.PropertyList
 
         internal void Write(Span<byte> bytes)
         {
-            #if SPAN_NATIVE
+            #if NATIVE_SPAN
             outStream.Write(bytes);
             count += bytes.Length;
-#else
+            #else
             Write(bytes.ToArray());
             #endif
         }

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0;netstandard2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <VersionPrefix>2.1</VersionPrefix>
     <Authors>Natalia Portillo</Authors>
     <Company>Claunia.com</Company>
@@ -36,12 +36,8 @@ Use invariant culture to format NSDate.</PackageReleaseNotes>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('netstandard'))">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.2' Or $(TargetFramework.StartsWith('netcoreapp.3.'))">
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net45' AND '$(TargetFramework)' != 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);NATIVE_SPAN</DefineConstants>
   </PropertyGroup>
 
@@ -49,8 +45,8 @@ Use invariant culture to format NSDate.</PackageReleaseNotes>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
-    <PackageReference Include="System.Memory" Version="4.5.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds support for .NET 5.0, and drops support for .NET Core 2.0, 2.2 and 3.0 (which are no longer supported: https://dotnet.microsoft.com/platform/support/policy/dotnet-core).

So the full list of supported versions now is:
- .NET 4.5,
- .NET Standard 2.0
- .NET Core 2.1
- .NET Core 3.1.
- .NET 5.0

While we're at it, clean up the conditional compilation constants and dependencies:
- Define `SPAN_NATIVE` on all platforms _except_ `net45` and `netstandard2.0` (so it's defined automatically on new .NET versions)
- Only add `System.Memory` dependency on `net45` and `netstandard2.0`.
- Fix `NATIVE_SPAN` typo
- Remove obsolete `NETCORE` preprocessor variable.

Fixes #69 