### PR TITLE
Optional dictionary key sorting on XML serialization

### DIFF
--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -188,5 +188,22 @@ namespace plistcil.test
             Assert.IsType<double>(weight);
             Assert.Equal(10d, (double)weight);
         }
+
+        /// <summary>
+        ///     Makes sure that dictionaries serialize to XML with keys sorted ordinally when specified.
+        /// </summary>
+        [Fact]
+        public static void SortedSerializationOptionTest()
+        {
+            string expected = File.ReadAllText(@"test-files/SortedKeys.plist");
+            NSDictionary dictionary = new NSDictionary();
+            dictionary["b"] = new NSString("Middle string");
+            dictionary["c"] = new NSString("Last string");
+            dictionary["a"] = new NSString("First string");
+            
+            string actual = dictionary.ToXmlPropertyList(XmlSerializationOptions.SortDictionaries);
+
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+        }
     }
 }

--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -196,7 +196,17 @@ namespace plistcil.test
         public static void SortedSerializationOptionTest()
         {
             string expected = File.ReadAllText(@"test-files/SortedKeys.plist");
+
+            NSDictionary nestedDictionary = new NSDictionary();
+            nestedDictionary["c"] = new NSString("Last string");
+            nestedDictionary["a"] = new NSString("First string");
+            nestedDictionary["b"] = new NSString("Middle string");
+
+            NSArray array = new NSArray();
+            array.Add(nestedDictionary);
+
             NSDictionary dictionary = new NSDictionary();
+            dictionary["d"] = array;
             dictionary["b"] = new NSString("Middle string");
             dictionary["c"] = new NSString("Last string");
             dictionary["a"] = new NSString("First string");

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <ReleaseVersion>1.14</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -122,6 +123,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="test-files\RoundtripBinaryIndentation.plist">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="test-files\SortedKeys.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/plist-cil.test/test-files/SortedKeys.plist
+++ b/plist-cil.test/test-files/SortedKeys.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>a</key>
+	<string>First string</string>
+	<key>b</key>
+	<string>Middle string</string>
+	<key>c</key>
+	<string>Last string</string>
+</dict>
+</plist>

--- a/plist-cil.test/test-files/SortedKeys.plist
+++ b/plist-cil.test/test-files/SortedKeys.plist
@@ -8,5 +8,16 @@
 	<string>Middle string</string>
 	<key>c</key>
 	<string>Last string</string>
+	<key>d</key>
+	<array>
+		<dict>
+			<key>a</key>
+			<string>First string</string>
+			<key>b</key>
+			<string>Middle string</string>
+			<key>c</key>
+			<string>Last string</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/plist-cil/NSArray.cs
+++ b/plist-cil/NSArray.cs
@@ -190,7 +190,7 @@ namespace Claunia.PropertyList
             return hash;
         }
 
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null)
         {
             Indent(xml, level);
             xml.Append("<array>");
@@ -198,7 +198,7 @@ namespace Claunia.PropertyList
 
             foreach(NSObject o in array)
             {
-                o.ToXml(xml, level + 1);
+                o.ToXml(xml, level + 1, options);
                 xml.Append(NEWLINE);
             }
 

--- a/plist-cil/NSData.cs
+++ b/plist-cil/NSData.cs
@@ -112,7 +112,7 @@ namespace Claunia.PropertyList
             return hash;
         }
 
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
         {
             Indent(xml, level);
             xml.Append("<data>");

--- a/plist-cil/NSDate.cs
+++ b/plist-cil/NSDate.cs
@@ -114,7 +114,7 @@ namespace Claunia.PropertyList
         /// </returns>
         public override int GetHashCode() => Date.GetHashCode();
 
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
         {
             Indent(xml, level);
             xml.Append("<date>");

--- a/plist-cil/NSDictionary.cs
+++ b/plist-cil/NSDictionary.cs
@@ -284,13 +284,26 @@ namespace Claunia.PropertyList
             return hash;
         }
 
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null)
         {
             Indent(xml, level);
             xml.Append("<dict>");
             xml.Append(NEWLINE);
 
-            foreach(KeyValuePair<string, NSObject> kvp in dict)
+            IDictionary<string, NSObject> serializableDict;
+            if(
+                options is XmlSerializationOptions unwrappedOptions &&
+                unwrappedOptions.HasFlag(XmlSerializationOptions.SortDictionaries)
+            )
+            { 
+                serializableDict = new SortedDictionary<string, NSObject>(dict, StringComparer.Ordinal);
+            }
+            else
+            {
+                serializableDict = dict;
+            }
+
+            foreach(KeyValuePair<string, NSObject> kvp in serializableDict)
             {
                 Indent(xml, level + 1);
                 xml.Append("<key>");
@@ -310,7 +323,7 @@ namespace Claunia.PropertyList
 
                 xml.Append("</key>");
                 xml.Append(NEWLINE);
-                kvp.Value.ToXml(xml, level + 1);
+                kvp.Value.ToXml(xml, level + 1, options);
                 xml.Append(NEWLINE);
             }
 

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -320,7 +320,7 @@ namespace Claunia.PropertyList
             _       => base.ToString()
         };
 
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
         {
             Indent(xml, level);
 

--- a/plist-cil/NSObject.cs
+++ b/plist-cil/NSObject.cs
@@ -55,7 +55,8 @@ namespace Claunia.PropertyList
         /// <summary>Generates the XML representation of the object (without XML headers or enclosing plist-tags).</summary>
         /// <param name="xml">The StringBuilder onto which the XML representation is appended.</param>
         /// <param name="level">The indentation level of the object.</param>
-        internal abstract void ToXml(StringBuilder xml, int level);
+        /// <param name="options">Serialization options (nullable).</param>
+        internal abstract void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null);
 
         /// <summary>Assigns IDs to all the objects in this NSObject subtree.</summary>
         /// <param name="outPlist">The writer object that handles the binary serialization.</param>
@@ -69,13 +70,21 @@ namespace Claunia.PropertyList
         /// <returns>The XML representation of the property list including XML header and doctype information.</returns>
         public string ToXmlPropertyList()
         {
+            return ToXmlPropertyList(null);
+        }
+
+        /// <summary>Generates a valid XML property list including headers using this object as root.</summary>
+        /// <param name="options">Serialization options (nullable).</param>
+        /// <returns>The XML representation of the property list including XML header and doctype information.</returns>
+        public string ToXmlPropertyList(XmlSerializationOptions? options = null)
+        {
             var xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
             xml.Append(NEWLINE);
             xml.Append("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">");
             xml.Append(NEWLINE);
             xml.Append("<plist version=\"1.0\">");
             xml.Append(NEWLINE);
-            ToXml(xml, 0);
+            ToXml(xml, 0, options);
             xml.Append(NEWLINE);
             xml.Append("</plist>");
             xml.Append(NEWLINE);

--- a/plist-cil/NSSet.cs
+++ b/plist-cil/NSSet.cs
@@ -233,7 +233,7 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <param name="xml">The XML StringBuilder</param>
         /// <param name="level">The indentation level</param>
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
         {
             Indent(xml, level);
             xml.Append("<array>");

--- a/plist-cil/NSString.cs
+++ b/plist-cil/NSString.cs
@@ -113,7 +113,7 @@ namespace Claunia.PropertyList
         /// <returns>The NSString's contents.</returns>
         public override string ToString() => Content;
 
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
         {
             Indent(xml, level);
             xml.Append("<string>");

--- a/plist-cil/UID.cs
+++ b/plist-cil/UID.cs
@@ -136,7 +136,7 @@ namespace Claunia.PropertyList
         /// </summary>
         /// <param name="xml">The xml StringBuilder</param>
         /// <param name="level">The indentation level</param>
-        internal override void ToXml(StringBuilder xml, int level)
+        internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
         {
             Indent(xml, level);
             xml.Append("<dict>");

--- a/plist-cil/XmlSerializationOptions.cs
+++ b/plist-cil/XmlSerializationOptions.cs
@@ -1,0 +1,32 @@
+// plist-cil - An open source library to parse and generate property lists for .NET
+// Copyright (C) 2015 Natalia Portillo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+
+namespace Claunia.PropertyList
+{
+    [Flags]
+    public enum XmlSerializationOptions
+    {
+        SortDictionaries
+    }
+}
+


### PR DESCRIPTION
This PR adds the option to sort dictionary keys on XML serialization that was discussed in #74. Unit testing for the new option is also included.

I've implemented the change on an opt-in basis as preferred in our discussion, and I hope it's ready for merging.

Closes #74.