### PR TITLE
NSString: Use SecurityElement.Escape to escape XML characters

### DIFF
--- a/plist-cil.test/NSStringTests.cs
+++ b/plist-cil.test/NSStringTests.cs
@@ -1,0 +1,29 @@
+using Claunia.PropertyList;
+using Xunit;
+
+namespace plistcil.test
+{
+    public class NSStringTests
+    {
+        const string START_TOKEN = "<string>";
+        const string END_TOKEN = "</string>";
+
+        [InlineData("abc", "abc")]
+        [InlineData("a>b", "a&gt;b")]
+        [InlineData("a<b", "a&lt;b")]
+        [InlineData("a&b", "a&amp;b")]
+        [Theory]
+        public void Content_IsEscaped(string value, string content)
+        {
+            var element = new NSString(value);
+            string xml = element.ToXmlPropertyList();
+
+            // Strip the leading and trailing data, so we just get the string element itself
+            int start = xml.IndexOf(START_TOKEN) + START_TOKEN.Length;
+            int end = xml.IndexOf(END_TOKEN);
+            string actualContent = xml.Substring(start, end - start);
+
+            Assert.Equal(content, actualContent);
+        }
+    }
+}

--- a/plist-cil/NSString.cs
+++ b/plist-cil/NSString.cs
@@ -1,4 +1,4 @@
-﻿// plist-cil - An open source library to parse and generate property lists for .NET
+// plist-cil - An open source library to parse and generate property lists for .NET
 // Copyright (C) 2015 Natalia Portillo
 //
 // This code is based on:
@@ -24,6 +24,7 @@
 // SOFTWARE.
 
 using System;
+using System.Security;
 using System.Text;
 
 namespace Claunia.PropertyList
@@ -136,16 +137,7 @@ namespace Claunia.PropertyList
 
             //According to http://www.w3.org/TR/REC-xml/#syntax node values must not
             //contain the characters < or &. Also the > character should be escaped.
-            if(Content.Contains("&") ||
-               Content.Contains("<") ||
-               Content.Contains(">"))
-            {
-                xml.Append("<![CDATA[");
-                xml.Append(Content.Replace("]]>", "]]]]><![CDATA[>"));
-                xml.Append("]]>");
-            }
-            else
-                xml.Append(Content);
+            xml.Append(SecurityElement.Escape(Content));
 
             xml.Append("</string>");
         }


### PR DESCRIPTION
We've hit a scenario where a GNUstep-based application has a hard time processing a property list with `CDATA` elements in it.  It works well if you XML-encode characters instead, and the Apple implementation of the XML property list format appears to be just fine with it, too.

To maintain compatibility with this application, we find it works better if we XML-encode any characters.  So `a>b` -> `a&gt;b` instead of `<![CDATA[a>b]]>`.

This PR implements just that. 