### PR TITLE
Add NerdBank.GitVersioning support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,10 +23,13 @@ jobs:
     - name: Create NuGet packages
       run: |
         dotnet pack -c Release -o nuget/
+    - name: Get version information
+      uses: dotnet/nbgv@master
+      id: nbgv
     - name: Publish NuGet packages as artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: plist-cil
+        name: plist-cil-${{ steps.nbgv.outputs.SemVer2 }}
         path: nuget/
     - name: Publish NuGet packages to NuGet feed
       run: |

--- a/plist-cil/plist-cil.csproj
+++ b/plist-cil/plist-cil.csproj
@@ -48,6 +48,7 @@ Add .NET 5.0 support.</PackageReleaseNotes>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.112" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">

--- a/version.json
+++ b/version.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "2.2",
+    "publicReleaseRefSpec": [
+      "^refs/heads/master$",
+      "^refs/heads/releases/*"
+    ]
+}


### PR DESCRIPTION
This commit adds [NerdBank.GitVersioning](https://www.nuget.org/packages/Nerdbank.GitVersioning), which gives every build of plist-cil a unique version number.

The base version number is stored in `version.json` (e.g. 2.2) and is incremented by 1 every time a commit is added.  Builds off branches contain a `+g{commit}` suffix, indicating that these builds are prerelease.

This makes it easier to keep track of different versions of plist-cil.