### PR TITLE
Allow NSObject Wrap to handle lists of maps/dicts.

### DIFF
--- a/plist-cil.test/ParseTest.cs
+++ b/plist-cil.test/ParseTest.cs
@@ -1,4 +1,4 @@
-﻿// plist-cil - An open source library to Parse and generate property lists for .NET
+// plist-cil - An open source library to Parse and generate property lists for .NET
 // Copyright (C) 2015 Natalia Portillo
 //
 // This code is based on:
@@ -209,6 +209,16 @@ namespace plistcil.test
             map.Add("long", lng);
             map.Add("date", date);
 
+            List<Dictionary<string,object>> listOfMaps = new()
+            {
+                new Dictionary<string, object>
+                {
+                    { "int", i },
+                    { "long", lng },
+                    { "date", date }
+                }
+            };
+
             var WrappedO = NSObject.Wrap((object)bl);
             Assert.True(WrappedO is (NSNumber));
             Assert.True(WrappedO.ToObject().Equals(bl));
@@ -273,6 +283,15 @@ namespace plistcil.test
             Assert.True(((NSNumber)dict.ObjectForKey("int")).ToLong()  == i);
             Assert.True(((NSNumber)dict.ObjectForKey("long")).ToLong() == lng);
             Assert.True(((NSDate)dict.ObjectForKey("date")).Date.Equals(date));
+
+            WrappedO = NSObject.Wrap((object)listOfMaps);
+            Assert.True(WrappedO is (NSArray));
+            var arrayOfMaps = (NSArray)WrappedO;
+            Assert.True(arrayOfMaps.Count == 1);
+            var firstMap = (NSDictionary)arrayOfMaps[0];
+            Assert.True(((NSNumber)firstMap.ObjectForKey("int")).ToLong() == i);
+            Assert.True(((NSNumber)firstMap.ObjectForKey("long")).ToLong() == lng);
+            Assert.True(((NSDate)firstMap.ObjectForKey("date")).Date.Equals(date));
 
             // TODO
             /*

--- a/plist-cil/NSObject.cs
+++ b/plist-cil/NSObject.cs
@@ -1,4 +1,4 @@
-﻿// plist-cil - An open source library to parse and generate property lists for .NET
+// plist-cil - An open source library to parse and generate property lists for .NET
 // Copyright (C) 2015 Natalia Portillo
 //
 // This code is based on:
@@ -320,6 +320,14 @@ namespace Claunia.PropertyList
 
             if(typeof(List<object>).IsAssignableFrom(c))
                 return Wrap(((List<object>)o).ToArray());
+
+            if(typeof(List<Dictionary<string, object>>).IsAssignableFrom(c))
+            {
+                var list = new NSArray();
+                foreach(Dictionary<string, object> dict in (List<Dictionary<string, object>>)o)
+                    list.Add(Wrap(dict));
+                return list;
+            }
 
             throw new PropertyListException($"Cannot wrap an object of type {o.GetType().Name}.");
         }


### PR DESCRIPTION
Allows NSObject's Wrap method to handle `List<Dictionary<string,object>>`. This came up while migrating some very old (BinaryFormatter reliant) plist code to this library. Lists of Dicts appear in AirPlay configuration requests.