### PR TITLE
Allow self closing tags for empty collections on XML serialization

### DIFF
--- a/plist-cil.test/IssueTest.cs
+++ b/plist-cil.test/IssueTest.cs
@@ -188,4 +188,17 @@ public static class IssueTest
         Assert.IsType<double>(weight);
         Assert.Equal(10d, (double)weight);
     }
+
+    /// <summary>
+    ///     Makes sure that empty dictionaries/arrays are serialized correctly if XmlSerializationOptions self-closing tags option is used.
+    /// </summary>
+    [Fact]
+    public static void SelfClosingTagsTest()
+    {
+        string   expected = File.ReadAllText(@"test-files/SelfClosingTags.plist");
+        NSObject value    = XmlPropertyListParser.Parse(new FileInfo(@"test-files/SelfClosingTags.plist"));
+        string   actual   = value.ToXmlPropertyList(XmlSerializationOptions.SelfClosingTags);
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
 }

--- a/plist-cil.test/plist-cil.test.csproj
+++ b/plist-cil.test/plist-cil.test.csproj
@@ -127,6 +127,9 @@
     <None Update="test-files\RoundtripBinaryIndentation.plist">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="test-files\SelfClosingTags.plist">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/plist-cil.test/test-files/SelfClosingTags.plist
+++ b/plist-cil.test/test-files/SelfClosingTags.plist
@@ -2,9 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>test2</key>
-	<array/>
 	<key>test</key>
 	<dict/>
+	<key>test2</key>
+	<array/>
+	<key>test3</key>
+	<dict>
+		<key>foo</key>
+		<string>bar</string>
+	</dict>
+	<key>test4</key>
+	<string></string>
 </dict>
 </plist>

--- a/plist-cil.test/test-files/SelfClosingTags.plist
+++ b/plist-cil.test/test-files/SelfClosingTags.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>test2</key>
+	<array/>
+	<key>test</key>
+	<dict/>
+</dict>
+</plist>

--- a/plist-cil/NSArray.cs
+++ b/plist-cil/NSArray.cs
@@ -183,20 +183,35 @@ public partial class NSArray : NSObject
         return hash;
     }
 
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null)
     {
         Indent(xml, level);
-        xml.Append("<array>");
-        xml.Append(NEWLINE);
 
-        foreach(NSObject o in array)
+        if(array.Count == 0)
         {
-            o.ToXml(xml, level + 1);
-            xml.Append(NEWLINE);
+            if(
+                options is XmlSerializationOptions unwrappedOptions &&
+                unwrappedOptions.HasFlag(XmlSerializationOptions.SelfClosingTags)
+            )
+            {
+                xml.Append("<array/>");
+                return;
+            }
         }
+        else
+        {
+            xml.Append("<array>");
+            xml.Append(NEWLINE);
 
-        Indent(xml, level);
-        xml.Append("</array>");
+            foreach(NSObject o in array)
+            {
+                o.ToXml(xml, level + 1, options);
+                xml.Append(NEWLINE);
+            }
+
+            Indent(xml, level);
+            xml.Append("</array>");
+        }
     }
 
     internal override void AssignIDs(BinaryPropertyListWriter outPlist)

--- a/plist-cil/NSArray.cs
+++ b/plist-cil/NSArray.cs
@@ -198,20 +198,18 @@ public partial class NSArray : NSObject
                 return;
             }
         }
-        else
+
+        xml.Append("<array>");
+        xml.Append(NEWLINE);
+
+        foreach(NSObject o in array)
         {
-            xml.Append("<array>");
+            o.ToXml(xml, level + 1, options);
             xml.Append(NEWLINE);
-
-            foreach(NSObject o in array)
-            {
-                o.ToXml(xml, level + 1, options);
-                xml.Append(NEWLINE);
-            }
-
-            Indent(xml, level);
-            xml.Append("</array>");
         }
+
+        Indent(xml, level);
+        xml.Append("</array>");
     }
 
     internal override void AssignIDs(BinaryPropertyListWriter outPlist)

--- a/plist-cil/NSData.cs
+++ b/plist-cil/NSData.cs
@@ -116,7 +116,7 @@ public class NSData : NSObject
         return hash;
     }
 
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
     {
         Indent(xml, level);
         xml.Append("<data>");

--- a/plist-cil/NSDate.cs
+++ b/plist-cil/NSDate.cs
@@ -114,7 +114,7 @@ public class NSDate : NSObject
     /// </returns>
     public override int GetHashCode() => Date.GetHashCode();
 
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
     {
         Indent(xml, level);
         xml.Append("<date>");

--- a/plist-cil/NSDictionary.cs
+++ b/plist-cil/NSDictionary.cs
@@ -281,36 +281,34 @@ public class NSDictionary : NSObject, IDictionary<string, NSObject>
                 return;
             }
         }
-        else
+
+        xml.Append("<dict>");
+        xml.Append(NEWLINE);
+
+        foreach(KeyValuePair<string, NSObject> kvp in dict)
         {
-            xml.Append("<dict>");
-            xml.Append(NEWLINE);
+            Indent(xml, level + 1);
+            xml.Append("<key>");
 
-            foreach(KeyValuePair<string, NSObject> kvp in dict)
+            //According to http://www.w3.org/TR/REC-xml/#syntax node values must not
+            //contain the characters < or &. Also the > character should be escaped.
+            if(kvp.Key.Contains("&") || kvp.Key.Contains("<") || kvp.Key.Contains(">"))
             {
-                Indent(xml, level + 1);
-                xml.Append("<key>");
-
-                //According to http://www.w3.org/TR/REC-xml/#syntax node values must not
-                //contain the characters < or &. Also the > character should be escaped.
-                if(kvp.Key.Contains("&") || kvp.Key.Contains("<") || kvp.Key.Contains(">"))
-                {
-                    xml.Append("<![CDATA[");
-                    xml.Append(kvp.Key.Replace("]]>", "]]]]><![CDATA[>"));
-                    xml.Append("]]>");
-                }
-                else
-                    xml.Append(kvp.Key);
-
-                xml.Append("</key>");
-                xml.Append(NEWLINE);
-                kvp.Value.ToXml(xml, level + 1, options);
-                xml.Append(NEWLINE);
+                xml.Append("<![CDATA[");
+                xml.Append(kvp.Key.Replace("]]>", "]]]]><![CDATA[>"));
+                xml.Append("]]>");
             }
+            else
+                xml.Append(kvp.Key);
 
-            Indent(xml, level);
-            xml.Append("</dict>");
+            xml.Append("</key>");
+            xml.Append(NEWLINE);
+            kvp.Value.ToXml(xml, level + 1, options);
+            xml.Append(NEWLINE);
         }
+
+        Indent(xml, level);
+        xml.Append("</dict>");
     }
 
     internal override void AssignIDs(BinaryPropertyListWriter outPlist)

--- a/plist-cil/NSDictionary.cs
+++ b/plist-cil/NSDictionary.cs
@@ -266,36 +266,51 @@ public class NSDictionary : NSObject, IDictionary<string, NSObject>
         return hash;
     }
 
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null)
     {
         Indent(xml, level);
-        xml.Append("<dict>");
-        xml.Append(NEWLINE);
 
-        foreach(KeyValuePair<string, NSObject> kvp in dict)
+        if(dict.Count == 0)
         {
-            Indent(xml, level + 1);
-            xml.Append("<key>");
-
-            //According to http://www.w3.org/TR/REC-xml/#syntax node values must not
-            //contain the characters < or &. Also the > character should be escaped.
-            if(kvp.Key.Contains("&") || kvp.Key.Contains("<") || kvp.Key.Contains(">"))
+            if(
+                options is XmlSerializationOptions unwrappedOptions &&
+                unwrappedOptions.HasFlag(XmlSerializationOptions.SelfClosingTags)
+            )
             {
-                xml.Append("<![CDATA[");
-                xml.Append(kvp.Key.Replace("]]>", "]]]]><![CDATA[>"));
-                xml.Append("]]>");
+                xml.Append("<dict/>");
+                return;
             }
-            else
-                xml.Append(kvp.Key);
-
-            xml.Append("</key>");
-            xml.Append(NEWLINE);
-            kvp.Value.ToXml(xml, level + 1);
-            xml.Append(NEWLINE);
         }
+        else
+        {
+            xml.Append("<dict>");
+            xml.Append(NEWLINE);
 
-        Indent(xml, level);
-        xml.Append("</dict>");
+            foreach(KeyValuePair<string, NSObject> kvp in dict)
+            {
+                Indent(xml, level + 1);
+                xml.Append("<key>");
+
+                //According to http://www.w3.org/TR/REC-xml/#syntax node values must not
+                //contain the characters < or &. Also the > character should be escaped.
+                if(kvp.Key.Contains("&") || kvp.Key.Contains("<") || kvp.Key.Contains(">"))
+                {
+                    xml.Append("<![CDATA[");
+                    xml.Append(kvp.Key.Replace("]]>", "]]]]><![CDATA[>"));
+                    xml.Append("]]>");
+                }
+                else
+                    xml.Append(kvp.Key);
+
+                xml.Append("</key>");
+                xml.Append(NEWLINE);
+                kvp.Value.ToXml(xml, level + 1, options);
+                xml.Append(NEWLINE);
+            }
+
+            Indent(xml, level);
+            xml.Append("</dict>");
+        }
     }
 
     internal override void AssignIDs(BinaryPropertyListWriter outPlist)

--- a/plist-cil/NSNumber.cs
+++ b/plist-cil/NSNumber.cs
@@ -318,7 +318,7 @@ public class NSNumber : NSObject, IComparable
                                              _       => base.ToString()
                                          };
 
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
     {
         Indent(xml, level);
 

--- a/plist-cil/NSObject.cs
+++ b/plist-cil/NSObject.cs
@@ -55,7 +55,8 @@ public abstract class NSObject
     /// <summary>Generates the XML representation of the object (without XML headers or enclosing plist-tags).</summary>
     /// <param name="xml">The StringBuilder onto which the XML representation is appended.</param>
     /// <param name="level">The indentation level of the object.</param>
-    internal abstract void ToXml(StringBuilder xml, int level);
+    /// <param name="options">Serialization options (nullable).</param>
+    internal abstract void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null);
 
     /// <summary>Assigns IDs to all the objects in this NSObject subtree.</summary>
     /// <param name="outPlist">The writer object that handles the binary serialization.</param>
@@ -69,13 +70,21 @@ public abstract class NSObject
     /// <returns>The XML representation of the property list including XML header and doctype information.</returns>
     public string ToXmlPropertyList()
     {
+        return ToXmlPropertyList(null);
+    }
+
+    /// <summary>Generates a valid XML property list including headers using this object as root.</summary>
+    /// <param name="options">Serialization options (nullable).</param>
+    /// <returns>The XML representation of the property list including XML header and doctype information.</returns>
+    public string ToXmlPropertyList(XmlSerializationOptions? options = null)
+    {
         var xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         xml.Append(NEWLINE);
         xml.Append("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">");
         xml.Append(NEWLINE);
         xml.Append("<plist version=\"1.0\">");
         xml.Append(NEWLINE);
-        ToXml(xml, 0);
+        ToXml(xml, 0, options);
         xml.Append(NEWLINE);
         xml.Append("</plist>");
         xml.Append(NEWLINE);

--- a/plist-cil/NSSet.cs
+++ b/plist-cil/NSSet.cs
@@ -248,22 +248,20 @@ public class NSSet : NSObject, IEnumerable
                 return;
             }
         }
-        else
+
+        xml.Append("<array>");
+        xml.Append(NEWLINE);
+
+        if(ordered) set.Sort();
+
+        foreach(NSObject o in set)
         {
-            xml.Append("<array>");
+            o.ToXml(xml, level + 1);
             xml.Append(NEWLINE);
-
-            if(ordered) set.Sort();
-
-            foreach(NSObject o in set)
-            {
-                o.ToXml(xml, level + 1);
-                xml.Append(NEWLINE);
-            }
-
-            Indent(xml, level);
-            xml.Append("</array>");
         }
+
+        Indent(xml, level);
+        xml.Append("</array>");
     }
 
     internal override void AssignIDs(BinaryPropertyListWriter outPlist)

--- a/plist-cil/NSSet.cs
+++ b/plist-cil/NSSet.cs
@@ -233,22 +233,37 @@ public class NSSet : NSObject, IEnumerable
     /// </summary>
     /// <param name="xml">The XML StringBuilder</param>
     /// <param name="level">The indentation level</param>
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? options = null)
     {
         Indent(xml, level);
-        xml.Append("<array>");
-        xml.Append(NEWLINE);
 
-        if(ordered) set.Sort();
-
-        foreach(NSObject o in set)
+        if(set.Count == 0)
         {
-            o.ToXml(xml, level + 1);
-            xml.Append(NEWLINE);
+            if(
+                options is XmlSerializationOptions unwrappedOptions &&
+                unwrappedOptions.HasFlag(XmlSerializationOptions.SelfClosingTags)
+            )
+            {
+                xml.Append("<array/>");
+                return;
+            }
         }
+        else
+        {
+            xml.Append("<array>");
+            xml.Append(NEWLINE);
 
-        Indent(xml, level);
-        xml.Append("</array>");
+            if(ordered) set.Sort();
+
+            foreach(NSObject o in set)
+            {
+                o.ToXml(xml, level + 1);
+                xml.Append(NEWLINE);
+            }
+
+            Indent(xml, level);
+            xml.Append("</array>");
+        }
     }
 
     internal override void AssignIDs(BinaryPropertyListWriter outPlist)

--- a/plist-cil/NSString.cs
+++ b/plist-cil/NSString.cs
@@ -116,7 +116,7 @@ public class NSString : NSObject, IComparable
     /// <returns>The NSString's contents.</returns>
     public override string ToString() => Content;
 
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
     {
         Indent(xml, level);
         xml.Append("<string>");

--- a/plist-cil/UID.cs
+++ b/plist-cil/UID.cs
@@ -134,7 +134,7 @@ public class UID : NSObject
     /// </summary>
     /// <param name="xml">The xml StringBuilder</param>
     /// <param name="level">The indentation level</param>
-    internal override void ToXml(StringBuilder xml, int level)
+    internal override void ToXml(StringBuilder xml, int level, XmlSerializationOptions? _)
     {
         Indent(xml, level);
         xml.Append("<dict>");

--- a/plist-cil/XmlSerializationOptions.cs
+++ b/plist-cil/XmlSerializationOptions.cs
@@ -1,0 +1,31 @@
+// plist-cil - An open source library to parse and generate property lists for .NET
+// Copyright (C) 2015 Natalia Portillo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+
+namespace Claunia.PropertyList
+{
+    [Flags]
+    public enum XmlSerializationOptions
+    {
+        SelfClosingTags
+    }
+}


### PR DESCRIPTION
**PROBLEM**
* Apple treats empty collections (`<array>`/`<dict>`) in plist/xml as self-closing `<array/>`/`<dict/>` instead of expanded format `<array></array>`/`<dict></dict>`.

**CHANGES**
* Allow self closing tags in XML serialization option (added in #75, but was not merged)
* Added test cases for handling empty collections